### PR TITLE
Fix script installation paths and add reset functionality

### DIFF
--- a/Editor/VibeUnityMenu.cs
+++ b/Editor/VibeUnityMenu.cs
@@ -461,6 +461,30 @@ namespace VibeUnity.Editor
             EditorUtility.DisplayDialog("Debug Information", info.ToString(), "OK");
             Debug.Log($"[Vibe Unity] Debug Info:\n{info.ToString()}");
         }
+
+        [MenuItem("Tools/Vibe Unity/Development/Reset Setup & Re-run", priority = 185)]
+        private static void ResetAndRerunSetup()
+        {
+            if (EditorUtility.DisplayDialog("Reset Setup", 
+                "This will reset the setup completion flag and re-run the CLI script installation.\n\n" +
+                "This is useful if you've updated the package and need to reinstall the scripts.\n\n" +
+                "Continue?", 
+                "Yes, Reset", "Cancel"))
+            {
+                // Clear the setup completion flag
+                EditorPrefs.DeleteKey("VibeUnity_SetupComplete");
+                
+                Debug.Log("[Vibe Unity] Setup completion flag cleared. Re-running setup...");
+                
+                // Force re-run the setup
+                VibeUnitySetup.ForceRunSetup();
+                
+                EditorUtility.DisplayDialog("Setup Complete", 
+                    "Setup has been reset and re-run!\n\n" +
+                    "Check the console for details about script installation.", 
+                    "OK");
+            }
+        }
         
         #endregion
         

--- a/Editor/VibeUnitySetup.cs
+++ b/Editor/VibeUnitySetup.cs
@@ -43,6 +43,7 @@ namespace VibeUnity.Editor
                 string packagePath = GetPackagePath();
                 if (string.IsNullOrEmpty(packagePath)) return;
                 
+                string runtimePath = Path.Combine(packagePath, "Runtime");
                 string scriptsPath = Path.Combine(packagePath, "Scripts");
                 string projectRoot = Directory.GetParent(Application.dataPath).FullName;
                 
@@ -71,25 +72,55 @@ namespace VibeUnity.Editor
                     AddToGitIgnore(projectRoot, "claude-compile-check.sh");
                 }
                 
-                // Copy vibe-unity script
-                string sourceScript = Path.Combine(scriptsPath, "vibe-unity");
-                string targetScript = Path.Combine(projectRoot, "vibe-unity");
+                // Copy vibe-unity script from Runtime folder
+                string sourceScript = Path.Combine(runtimePath, "vibe-unity");
+                string targetScript = Path.Combine(projectRoot, "Scripts", "vibe-unity");
                 
                 if (File.Exists(sourceScript))
                 {
-                    File.Copy(sourceScript, targetScript, true);
+                    Directory.CreateDirectory(Path.Combine(projectRoot, "Scripts"));
+                    
+                    // Read with preserved line endings and write to preserve LF
+                    string content = File.ReadAllText(sourceScript);
+                    // Ensure Unix line endings (LF only)
+                    content = content.Replace("\r\n", "\n").Replace("\r", "\n");
+                    File.WriteAllText(targetScript, content);
+                    
+                    // Make executable on Unix systems
+                    if (System.Environment.OSVersion.Platform == System.PlatformID.Unix)
+                    {
+                        System.Diagnostics.Process.Start("chmod", $"+x \"{targetScript}\"");
+                    }
+                    
                     Debug.Log($"[Vibe Unity] Copied CLI script to: {targetScript}");
+                    
+                    // Add to .gitignore to prevent line ending issues
+                    AddToGitIgnore(projectRoot, "vibe-unity");
                 }
                 
-                // Copy install script
-                string sourceInstaller = Path.Combine(scriptsPath, "install-vibe-unity");
+                // Copy install script from Runtime folder
+                string sourceInstaller = Path.Combine(runtimePath, "install-vibe-unity");
                 string targetInstaller = Path.Combine(projectRoot, "Scripts", "install-vibe-unity");
                 
                 if (File.Exists(sourceInstaller))
                 {
-                    Directory.CreateDirectory(Path.Combine(projectRoot, "Scripts"));
-                    File.Copy(sourceInstaller, targetInstaller, true);
+                    
+                    // Read with preserved line endings and write to preserve LF
+                    string content = File.ReadAllText(sourceInstaller);
+                    // Ensure Unix line endings (LF only)
+                    content = content.Replace("\r\n", "\n").Replace("\r", "\n");
+                    File.WriteAllText(targetInstaller, content);
+                    
+                    // Make executable on Unix systems
+                    if (System.Environment.OSVersion.Platform == System.PlatformID.Unix)
+                    {
+                        System.Diagnostics.Process.Start("chmod", $"+x \"{targetInstaller}\"");
+                    }
+                    
                     Debug.Log($"[Vibe Unity] Copied installer to: {targetInstaller}");
+                    
+                    // Add to .gitignore to prevent line ending issues
+                    AddToGitIgnore(projectRoot, "Scripts/install-vibe-unity");
                 }
             }
             catch (System.Exception e)
@@ -136,18 +167,65 @@ namespace VibeUnity.Editor
         private static string GetPackagePath()
         {
             // Try to find the package in various locations
+            string projectRoot = Directory.GetParent(Application.dataPath).FullName;
+            
             string[] searchPaths = {
-                Path.Combine(Application.dataPath, "..", "Packages", "com.vibe.unity"),
-                Path.Combine(Application.dataPath, "..", "Library", "PackageCache", "com.vibe.unity@1.0.0"),
-                Path.Combine(Application.dataPath, "VibeUnity") // Local package
+                // Git URL packages are cached in Library/PackageCache with various naming patterns
+                Path.Combine(projectRoot, "Library", "PackageCache", "com.vibe.unity@*"),
+                Path.Combine(projectRoot, "Library", "PackageCache", "com.ricoder.vibe-unity@*"),
+                // Local package in Packages folder
+                Path.Combine(projectRoot, "Packages", "com.vibe.unity"),
+                Path.Combine(projectRoot, "Packages", "com.ricoder.vibe-unity"),
+                // Embedded package
+                Path.Combine(Application.dataPath, "VibeUnity")
             };
             
-            foreach (string path in searchPaths)
+            foreach (string searchPattern in searchPaths)
             {
-                if (Directory.Exists(path))
+                if (searchPattern.Contains("@*"))
                 {
-                    return path;
+                    // Handle wildcard patterns for package cache
+                    string directory = Path.GetDirectoryName(searchPattern);
+                    if (Directory.Exists(directory))
+                    {
+                        string pattern = Path.GetFileName(searchPattern);
+                        string[] matchingDirs = Directory.GetDirectories(directory, pattern.Replace("@*", "@*"));
+                        if (matchingDirs.Length > 0)
+                        {
+                            // Return the first (and typically only) match
+                            return matchingDirs[0];
+                        }
+                    }
                 }
+                else if (Directory.Exists(searchPattern))
+                {
+                    return searchPattern;
+                }
+            }
+            
+            // Fallback: try to use Unity's PackageManager API
+            try
+            {
+                var listRequest = UnityEditor.PackageManager.Client.List();
+                while (!listRequest.IsCompleted)
+                {
+                    System.Threading.Thread.Sleep(10);
+                }
+                
+                if (listRequest.Status == UnityEditor.PackageManager.StatusCode.Success)
+                {
+                    foreach (var package in listRequest.Result)
+                    {
+                        if (package.name.Contains("vibe-unity") || package.name.Contains("com.vibe.unity"))
+                        {
+                            return package.resolvedPath;
+                        }
+                    }
+                }
+            }
+            catch (System.Exception e)
+            {
+                Debug.LogWarning($"[Vibe Unity] Could not use PackageManager API: {e.Message}");
             }
             
             return null;

--- a/Editor/VibeUnitySetup.cs
+++ b/Editor/VibeUnitySetup.cs
@@ -254,7 +254,13 @@ namespace VibeUnity.Editor
             };
         }
         
-        // Reset setup functionality removed - menu consolidated in VibeUnityMenu.cs
+        /// <summary>
+        /// Force re-run setup (called from menu)
+        /// </summary>
+        public static void ForceRunSetup()
+        {
+            RunSetup();
+        }
     }
 }
 #endif


### PR DESCRIPTION
## Summary
  This PR addresses the script copying issue after moving files from Scripts to Runtime folder and provides users
  with a way to force re-installation when needed.

  ## Changes

  ### Commit 1: Script Installation Path Fixes (`7488129`)
  • Fix script source paths: vibe-unity and install-vibe-unity now sourced from Runtime folder
  • Improve package path detection with wildcards for PackageCache
  • Add Unity PackageManager API fallback for reliable package location
  • Preserve Unix line endings (LF) when copying scripts to prevent execution issues
  • Add automatic chmod +x on Unix systems for proper script permissions
  • Add scripts to .gitignore to prevent line ending conflicts

  ### Commit 2: Setup Reset Functionality (`b0b619d`)
  • Add "Reset Setup & Re-run" menu option in Tools > Vibe Unity > Development
  • Allow users to force re-installation after package updates
  • Clear EditorPrefs setup completion flag and trigger fresh setup
  • Add ForceRunSetup() public method to VibeUnitySetup class
  • Provide user feedback with confirmation dialogs and console logging

  ## Test Plan
  - [x] Install package in Unity project
  - [x] Verify scripts copy correctly to project directory
  - [x] Test "Reset Setup & Re-run" menu option
  - [x] Verify scripts are executable on Unix systems
  - [x] Check console logs for proper feedback