### PR TITLE
fix: re-enable batch-mode CLI entry points disabled in v2.0

### DIFF
--- a/Editor/VibeUnityCLI.cs
+++ b/Editor/VibeUnityCLI.cs
@@ -568,7 +568,7 @@ namespace VibeUnity.Editor
         
         /// <summary>
         /// Command line entry point for adding UI buttons.
-        /// Usage: Unity -batchmode -quit -executeMethod VibeUnity.Editor.CLI.AddButtonFromCommandLine button_name [parent_name] [button_text] [width] [height] [anchor_preset]
+        /// Usage: Unity -batchmode -quit -executeMethod VibeUnity.Editor.CLI.AddButtonFromCommandLine button_name [parent_name] [scene_name] [button_text] [width] [height] [anchor_preset]
         /// </summary>
         public static void AddButtonFromCommandLine()
         {
@@ -576,22 +576,24 @@ namespace VibeUnity.Editor
             int idx = System.Array.FindIndex(args, arg => arg == "-executeMethod");
             if (idx == -1 || idx + 2 >= args.Length)
             {
-                Debug.LogError("[VibeUnityCLI] Invalid arguments. Usage: button_name [parent_name] [button_text] [width] [height] [anchor_preset]");
+                Debug.LogError("[VibeUnityCLI] Invalid arguments. Usage: button_name [parent_name] [scene_name] [button_text] [width] [height] [anchor_preset]");
                 EditorApplication.Exit(1);
                 return;
             }
 
             string buttonName = args[idx + 2];
             string parentName = args.Length > idx + 3 ? args[idx + 3] : null;
-            string buttonText = args.Length > idx + 4 ? args[idx + 4] : "Button";
-            float  width      = args.Length > idx + 5 ? float.Parse(args[idx + 5]) : 160f;
-            float  height     = args.Length > idx + 6 ? float.Parse(args[idx + 6]) : 30f;
-            string anchor     = args.Length > idx + 7 ? args[idx + 7] : "MiddleCenter";
+            string sceneName  = args.Length > idx + 4 ? args[idx + 4] : null;
+            string buttonText = args.Length > idx + 5 ? args[idx + 5] : "Button";
+            float  width      = args.Length > idx + 6 ? float.Parse(args[idx + 6]) : 160f;
+            float  height     = args.Length > idx + 7 ? float.Parse(args[idx + 7]) : 30f;
+            string anchor     = args.Length > idx + 8 ? args[idx + 8] : "MiddleCenter";
             if (string.IsNullOrEmpty(parentName)) parentName = null;
+            if (string.IsNullOrEmpty(sceneName))  sceneName  = null;
 
-            Debug.Log($"[VibeUnityCLI] Adding button: {buttonName} (parent: {parentName ?? "auto"}, text: \"{buttonText}\")");
+            Debug.Log($"[VibeUnityCLI] Adding button: {buttonName} (parent: {parentName ?? "auto"}, scene: {sceneName ?? "current"}, text: \"{buttonText}\")");
 
-            bool success = VibeUnityUI.AddButton(buttonName, parentName, null, buttonText, width, height, anchor);
+            bool success = VibeUnityUI.AddButton(buttonName, parentName, sceneName, buttonText, width, height, anchor);
             if (success)
             {
                 Debug.Log($"[VibeUnityCLI] ✅ Successfully added button: {buttonName}");
@@ -607,7 +609,7 @@ namespace VibeUnity.Editor
         
         /// <summary>
         /// Command line entry point for adding UI text.
-        /// Usage: Unity -batchmode -quit -executeMethod VibeUnity.Editor.CLI.AddTextFromCommandLine text_name [parent_name] [text_content] [font_size] [width] [height] [anchor_preset]
+        /// Usage: Unity -batchmode -quit -executeMethod VibeUnity.Editor.CLI.AddTextFromCommandLine text_name [parent_name] [scene_name] [text_content] [font_size] [width] [height] [anchor_preset]
         /// </summary>
         public static void AddTextFromCommandLine()
         {
@@ -615,23 +617,25 @@ namespace VibeUnity.Editor
             int idx = System.Array.FindIndex(args, arg => arg == "-executeMethod");
             if (idx == -1 || idx + 2 >= args.Length)
             {
-                Debug.LogError("[VibeUnityCLI] Invalid arguments. Usage: text_name [parent_name] [text_content] [font_size] [width] [height] [anchor_preset]");
+                Debug.LogError("[VibeUnityCLI] Invalid arguments. Usage: text_name [parent_name] [scene_name] [text_content] [font_size] [width] [height] [anchor_preset]");
                 EditorApplication.Exit(1);
                 return;
             }
 
             string textName    = args[idx + 2];
             string parentName  = args.Length > idx + 3 ? args[idx + 3] : null;
-            string textContent = args.Length > idx + 4 ? args[idx + 4] : "New Text";
-            int    fontSize    = args.Length > idx + 5 ? int.Parse(args[idx + 5]) : 14;
-            float  width       = args.Length > idx + 6 ? float.Parse(args[idx + 6]) : 200f;
-            float  height      = args.Length > idx + 7 ? float.Parse(args[idx + 7]) : 50f;
-            string anchor      = args.Length > idx + 8 ? args[idx + 8] : "MiddleCenter";
+            string sceneName   = args.Length > idx + 4 ? args[idx + 4] : null;
+            string textContent = args.Length > idx + 5 ? args[idx + 5] : "New Text";
+            int    fontSize    = args.Length > idx + 6 ? int.Parse(args[idx + 6]) : 14;
+            float  width       = args.Length > idx + 7 ? float.Parse(args[idx + 7]) : 200f;
+            float  height      = args.Length > idx + 8 ? float.Parse(args[idx + 8]) : 50f;
+            string anchor      = args.Length > idx + 9 ? args[idx + 9] : "MiddleCenter";
             if (string.IsNullOrEmpty(parentName)) parentName = null;
+            if (string.IsNullOrEmpty(sceneName))  sceneName  = null;
 
-            Debug.Log($"[VibeUnityCLI] Adding text: {textName} (parent: {parentName ?? "auto"}, content: \"{textContent}\")");
+            Debug.Log($"[VibeUnityCLI] Adding text: {textName} (parent: {parentName ?? "auto"}, scene: {sceneName ?? "current"}, content: \"{textContent}\")");
 
-            bool success = VibeUnityUI.AddText(textName, parentName, null, textContent, fontSize, width, height, anchor);
+            bool success = VibeUnityUI.AddText(textName, parentName, sceneName, textContent, fontSize, width, height, anchor);
             if (success)
             {
                 Debug.Log($"[VibeUnityCLI] ✅ Successfully added text: {textName}");

--- a/Editor/VibeUnityCLI.cs
+++ b/Editor/VibeUnityCLI.cs
@@ -439,157 +439,241 @@ namespace VibeUnity.Editor
         #region Command Line Interface Entry Points
         
         /// <summary>
-        /// Command line entry point for scene creation - DISABLED
-        /// Usage: Unity -batchmode -quit -executeMethod VibeUnity.Editor.CLI.CreateSceneFromCommandLine -projectPath "path/to/project" scene_name scene_path scene_type
+        /// Command line entry point for scene creation.
+        /// Usage: Unity -batchmode -quit -executeMethod VibeUnity.Editor.CLI.CreateSceneFromCommandLine -projectPath "path/to/project" scene_name scene_path [scene_type] [add_to_build]
         /// </summary>
         public static void CreateSceneFromCommandLine()
         {
-            // CLI commands disabled - functionality commented out
-            Debug.LogWarning("[VibeUnityCLI] CLI commands are disabled. Use internal API methods instead.");
-            return;
-            
-            /*
             string[] args = System.Environment.GetCommandLineArgs();
-            
-            // Find our arguments after -executeMethod
             int executeMethodIndex = System.Array.FindIndex(args, arg => arg == "-executeMethod");
-            if (executeMethodIndex == -1 || executeMethodIndex + 4 >= args.Length)
+            if (executeMethodIndex == -1 || executeMethodIndex + 3 >= args.Length)
             {
                 Debug.LogError("[VibeUnityCLI] Invalid arguments. Usage: scene_name scene_path [scene_type] [add_to_build]");
                 Debug.LogError("[VibeUnityCLI] Available scene types: " + string.Join(", ", GetAvailableSceneTypes()));
+                EditorApplication.Exit(1);
                 return;
             }
-            
+
             string sceneName = args[executeMethodIndex + 2];
             string scenePath = args[executeMethodIndex + 3];
             string sceneType = args.Length > executeMethodIndex + 4 ? args[executeMethodIndex + 4] : "DefaultGameObjects";
-            bool addToBuild = args.Length > executeMethodIndex + 5 ? bool.Parse(args[executeMethodIndex + 5]) : false;
-            
-            Debug.Log($"[VibeUnityCLI] Creating scene: {sceneName} at {scenePath} (type: {sceneType})");
-            
+            bool addToBuild = args.Length > executeMethodIndex + 5 && bool.Parse(args[executeMethodIndex + 5]);
+
+            Debug.Log($"[VibeUnityCLI] Creating scene: {sceneName} at {scenePath} (type: {sceneType}, addToBuild: {addToBuild})");
+
             bool success = CreateScene(sceneName, scenePath, sceneType, addToBuild);
-            
             if (success)
             {
                 Debug.Log($"[VibeUnityCLI] ✅ Successfully created scene: {scenePath}/{sceneName}.unity");
+                EditorApplication.Exit(0);
             }
             else
             {
-                Debug.LogError($"[VibeUnityCLI] ❌ Failed to create scene");
-                UnityEditor.EditorApplication.Exit(1);
+                Debug.LogError("[VibeUnityCLI] ❌ Failed to create scene");
+                EditorApplication.Exit(1);
             }
-            */
         }
         
         /// <summary>
-        /// Command line entry point for canvas creation - DISABLED
-        /// Usage: Unity -batchmode -quit -executeMethod VibeUnity.Editor.CLI.AddCanvasFromCommandLine canvas_name [scene_name] render_mode [width] [height] [scale_mode]
+        /// Command line entry point for canvas creation.
+        /// Usage: Unity -batchmode -quit -executeMethod VibeUnity.Editor.CLI.AddCanvasFromCommandLine canvas_name [scene_name] [render_mode] [width] [height] [scale_mode]
         /// </summary>
         public static void AddCanvasFromCommandLine()
         {
-            // CLI commands disabled - functionality commented out
-            Debug.LogWarning("[VibeUnityCLI] CLI commands are disabled. Use internal API methods instead.");
-            return;
-            
-            /*
             string[] args = System.Environment.GetCommandLineArgs();
-            
             int executeMethodIndex = System.Array.FindIndex(args, arg => arg == "-executeMethod");
             if (executeMethodIndex == -1 || executeMethodIndex + 2 >= args.Length)
             {
-                Debug.LogError("[VibeUnityCLI] Invalid arguments. Usage: canvas_name [scene_name] render_mode [width] [height] [scale_mode]");
+                Debug.LogError("[VibeUnityCLI] Invalid arguments. Usage: canvas_name [scene_name] [render_mode] [width] [height] [scale_mode]");
                 Debug.LogError("[VibeUnityCLI] Render modes: ScreenSpaceOverlay, ScreenSpaceCamera, WorldSpace");
+                EditorApplication.Exit(1);
                 return;
             }
-            
+
             string canvasName = args[executeMethodIndex + 2];
             string sceneName = args.Length > executeMethodIndex + 3 ? args[executeMethodIndex + 3] : null;
             string renderMode = args.Length > executeMethodIndex + 4 ? args[executeMethodIndex + 4] : "ScreenSpaceOverlay";
             int width = args.Length > executeMethodIndex + 5 ? int.Parse(args[executeMethodIndex + 5]) : 1920;
             int height = args.Length > executeMethodIndex + 6 ? int.Parse(args[executeMethodIndex + 6]) : 1080;
             string scaleMode = args.Length > executeMethodIndex + 7 ? args[executeMethodIndex + 7] : "ScaleWithScreenSize";
-            
-            // Handle empty string as null for optional parameters
             if (string.IsNullOrEmpty(sceneName)) sceneName = null;
-            
+
             Debug.Log($"[VibeUnityCLI] Adding canvas: {canvasName} in scene {sceneName ?? "current"} ({renderMode}, {width}x{height})");
-            
+
             bool success = AddCanvas(canvasName, sceneName, renderMode, width, height, scaleMode);
-            
             if (success)
             {
                 Debug.Log($"[VibeUnityCLI] ✅ Successfully added canvas: {canvasName}");
-                
-                // Save the scene
-                UnityEditor.SceneManagement.EditorSceneManager.SaveOpenScenes();
+                EditorSceneManager.SaveOpenScenes();
+                EditorApplication.Exit(0);
             }
             else
             {
-                Debug.LogError($"[VibeUnityCLI] ❌ Failed to add canvas");
-                UnityEditor.EditorApplication.Exit(1);
+                Debug.LogError("[VibeUnityCLI] ❌ Failed to add canvas");
+                EditorApplication.Exit(1);
             }
-            */
         }
         
         /// <summary>
-        /// Command line entry point for listing scene types - DISABLED
+        /// Command line entry point for listing scene types.
         /// Usage: Unity -batchmode -quit -executeMethod VibeUnity.Editor.CLI.ListSceneTypesFromCommandLine
         /// </summary>
         public static void ListSceneTypesFromCommandLine()
         {
-            // CLI commands disabled - functionality commented out
-            Debug.LogWarning("[VibeUnityCLI] CLI commands are disabled. Use internal API methods instead.");
-            return;
-            
-            /*
             Debug.Log("[VibeUnityCLI] === Available Scene Types ===");
             ListSceneTypes();
             Debug.Log("[VibeUnityCLI] ===========================");
-            */
+            EditorApplication.Exit(0);
         }
         
         /// <summary>
-        /// Command line entry point for adding UI panels - DISABLED
+        /// Command line entry point for adding UI panels.
         /// Usage: Unity -batchmode -quit -executeMethod VibeUnity.Editor.CLI.AddPanelFromCommandLine panel_name [parent_name] [scene_name] [width] [height] [anchor_preset]
         /// </summary>
         public static void AddPanelFromCommandLine()
         {
-            // CLI commands disabled - functionality commented out
-            Debug.LogWarning("[VibeUnityCLI] CLI commands are disabled. Use internal API methods instead.");
-            return;
+            string[] args = System.Environment.GetCommandLineArgs();
+            int idx = System.Array.FindIndex(args, arg => arg == "-executeMethod");
+            if (idx == -1 || idx + 2 >= args.Length)
+            {
+                Debug.LogError("[VibeUnityCLI] Invalid arguments. Usage: panel_name [parent_name] [scene_name] [width] [height] [anchor_preset]");
+                EditorApplication.Exit(1);
+                return;
+            }
+
+            string panelName  = args[idx + 2];
+            string parentName = args.Length > idx + 3 ? args[idx + 3] : null;
+            string sceneName  = args.Length > idx + 4 ? args[idx + 4] : null;
+            float  width      = args.Length > idx + 5 ? float.Parse(args[idx + 5]) : 200f;
+            float  height     = args.Length > idx + 6 ? float.Parse(args[idx + 6]) : 200f;
+            string anchor     = args.Length > idx + 7 ? args[idx + 7] : "MiddleCenter";
+            if (string.IsNullOrEmpty(parentName)) parentName = null;
+            if (string.IsNullOrEmpty(sceneName))  sceneName  = null;
+
+            Debug.Log($"[VibeUnityCLI] Adding panel: {panelName} (parent: {parentName ?? "auto"}, scene: {sceneName ?? "current"})");
+
+            bool success = VibeUnityUI.AddPanel(panelName, parentName, sceneName, width, height, anchor);
+            if (success)
+            {
+                Debug.Log($"[VibeUnityCLI] ✅ Successfully added panel: {panelName}");
+                EditorSceneManager.SaveOpenScenes();
+                EditorApplication.Exit(0);
+            }
+            else
+            {
+                Debug.LogError("[VibeUnityCLI] ❌ Failed to add panel");
+                EditorApplication.Exit(1);
+            }
         }
         
         /// <summary>
-        /// Command line entry point for adding UI buttons - DISABLED
-        /// Usage: Unity -batchmode -quit -executeMethod VibeUnity.Editor.CLI.AddButtonFromCommandLine button_name [parent_name] [scene_name] [button_text] [width] [height] [anchor_preset]
+        /// Command line entry point for adding UI buttons.
+        /// Usage: Unity -batchmode -quit -executeMethod VibeUnity.Editor.CLI.AddButtonFromCommandLine button_name [parent_name] [button_text] [width] [height] [anchor_preset]
         /// </summary>
         public static void AddButtonFromCommandLine()
         {
-            // CLI commands disabled - functionality commented out
-            Debug.LogWarning("[VibeUnityCLI] CLI commands are disabled. Use internal API methods instead.");
-            return;
+            string[] args = System.Environment.GetCommandLineArgs();
+            int idx = System.Array.FindIndex(args, arg => arg == "-executeMethod");
+            if (idx == -1 || idx + 2 >= args.Length)
+            {
+                Debug.LogError("[VibeUnityCLI] Invalid arguments. Usage: button_name [parent_name] [button_text] [width] [height] [anchor_preset]");
+                EditorApplication.Exit(1);
+                return;
+            }
+
+            string buttonName = args[idx + 2];
+            string parentName = args.Length > idx + 3 ? args[idx + 3] : null;
+            string buttonText = args.Length > idx + 4 ? args[idx + 4] : "Button";
+            float  width      = args.Length > idx + 5 ? float.Parse(args[idx + 5]) : 160f;
+            float  height     = args.Length > idx + 6 ? float.Parse(args[idx + 6]) : 30f;
+            string anchor     = args.Length > idx + 7 ? args[idx + 7] : "MiddleCenter";
+            if (string.IsNullOrEmpty(parentName)) parentName = null;
+
+            Debug.Log($"[VibeUnityCLI] Adding button: {buttonName} (parent: {parentName ?? "auto"}, text: \"{buttonText}\")");
+
+            bool success = VibeUnityUI.AddButton(buttonName, parentName, null, buttonText, width, height, anchor);
+            if (success)
+            {
+                Debug.Log($"[VibeUnityCLI] ✅ Successfully added button: {buttonName}");
+                EditorSceneManager.SaveOpenScenes();
+                EditorApplication.Exit(0);
+            }
+            else
+            {
+                Debug.LogError("[VibeUnityCLI] ❌ Failed to add button");
+                EditorApplication.Exit(1);
+            }
         }
         
         /// <summary>
-        /// Command line entry point for adding UI text - DISABLED
-        /// Usage: Unity -batchmode -quit -executeMethod VibeUnity.Editor.CLI.AddTextFromCommandLine text_name [parent_name] [scene_name] [text_content] [font_size] [width] [height] [anchor_preset]
+        /// Command line entry point for adding UI text.
+        /// Usage: Unity -batchmode -quit -executeMethod VibeUnity.Editor.CLI.AddTextFromCommandLine text_name [parent_name] [text_content] [font_size] [width] [height] [anchor_preset]
         /// </summary>
         public static void AddTextFromCommandLine()
         {
-            // CLI commands disabled - functionality commented out
-            Debug.LogWarning("[VibeUnityCLI] CLI commands are disabled. Use internal API methods instead.");
-            return;
+            string[] args = System.Environment.GetCommandLineArgs();
+            int idx = System.Array.FindIndex(args, arg => arg == "-executeMethod");
+            if (idx == -1 || idx + 2 >= args.Length)
+            {
+                Debug.LogError("[VibeUnityCLI] Invalid arguments. Usage: text_name [parent_name] [text_content] [font_size] [width] [height] [anchor_preset]");
+                EditorApplication.Exit(1);
+                return;
+            }
+
+            string textName    = args[idx + 2];
+            string parentName  = args.Length > idx + 3 ? args[idx + 3] : null;
+            string textContent = args.Length > idx + 4 ? args[idx + 4] : "New Text";
+            int    fontSize    = args.Length > idx + 5 ? int.Parse(args[idx + 5]) : 14;
+            float  width       = args.Length > idx + 6 ? float.Parse(args[idx + 6]) : 200f;
+            float  height      = args.Length > idx + 7 ? float.Parse(args[idx + 7]) : 50f;
+            string anchor      = args.Length > idx + 8 ? args[idx + 8] : "MiddleCenter";
+            if (string.IsNullOrEmpty(parentName)) parentName = null;
+
+            Debug.Log($"[VibeUnityCLI] Adding text: {textName} (parent: {parentName ?? "auto"}, content: \"{textContent}\")");
+
+            bool success = VibeUnityUI.AddText(textName, parentName, null, textContent, fontSize, width, height, anchor);
+            if (success)
+            {
+                Debug.Log($"[VibeUnityCLI] ✅ Successfully added text: {textName}");
+                EditorSceneManager.SaveOpenScenes();
+                EditorApplication.Exit(0);
+            }
+            else
+            {
+                Debug.LogError("[VibeUnityCLI] ❌ Failed to add text");
+                EditorApplication.Exit(1);
+            }
         }
         
         /// <summary>
-        /// Command line entry point for batch file execution - DISABLED
+        /// Command line entry point for batch file execution.
         /// Usage: Unity -batchmode -quit -executeMethod VibeUnity.Editor.CLI.ExecuteBatchFromCommandLine json_file_path
         /// </summary>
         public static void ExecuteBatchFromCommandLine()
         {
-            // CLI commands disabled - functionality commented out
-            Debug.LogWarning("[VibeUnityCLI] CLI commands are disabled. Use internal API methods instead.");
-            return;
+            string[] args = System.Environment.GetCommandLineArgs();
+            int idx = System.Array.FindIndex(args, arg => arg == "-executeMethod");
+            if (idx == -1 || idx + 2 >= args.Length)
+            {
+                Debug.LogError("[VibeUnityCLI] Invalid arguments. Usage: json_file_path");
+                EditorApplication.Exit(1);
+                return;
+            }
+
+            string jsonFilePath = args[idx + 2];
+            Debug.Log($"[VibeUnityCLI] Executing batch file: {jsonFilePath}");
+
+            bool success = VibeUnityJSONProcessor.ProcessBatchFileWithLogging(jsonFilePath);
+            if (success)
+            {
+                Debug.Log("[VibeUnityCLI] ✅ Batch file executed successfully");
+                EditorApplication.Exit(0);
+            }
+            else
+            {
+                Debug.LogError("[VibeUnityCLI] ❌ Batch file execution failed");
+                EditorApplication.Exit(1);
+            }
         }
         
         /// <summary>

--- a/Editor/VibeUnityJSONProcessor.cs
+++ b/Editor/VibeUnityJSONProcessor.cs
@@ -65,8 +65,9 @@ namespace VibeUnity.Editor
                 logCapture.AppendLine($"Description: {batchFile.description}");
                 logCapture.AppendLine();
                 
-                // Handle scene configuration if present
-                if (batchFile.scene != null)
+                // Handle scene configuration if present (JsonUtility never returns null for
+                // object fields, so check name is non-empty to detect an actual scene block)
+                if (batchFile.scene != null && !string.IsNullOrEmpty(batchFile.scene.name))
                 {
                     if (!EnsureSceneLoadedWithSceneConfig(batchFile.scene, logCapture))
                     {
@@ -599,62 +600,57 @@ namespace VibeUnity.Editor
         
         private static bool ExecuteAddCubeCommandWithLogging(BatchCommand command, StringBuilder logCapture)
         {
-            Vector3 position = command.position != null && command.position.Length >= 3 ? 
+            Vector3 position = command.position != null && command.position.Length >= 3 ?
                 new Vector3(command.position[0], command.position[1], command.position[2]) : Vector3.zero;
-            Vector3 rotation = command.rotation != null && command.rotation.Length >= 3 ? 
+            Vector3 rotation = command.rotation != null && command.rotation.Length >= 3 ?
                 new Vector3(command.rotation[0], command.rotation[1], command.rotation[2]) : Vector3.zero;
-            Vector3 scale = command.scale != null && command.scale.Length >= 3 ? 
+            Vector3 scale = command.scale != null && command.scale.Length >= 3 ?
                 new Vector3(command.scale[0], command.scale[1], command.scale[2]) : Vector3.one;
-                
-            return VibeUnityPrimitives.CreatePrimitiveWithLogging(command.name, PrimitiveType.Cube, position, rotation, scale, logCapture, "Cube");
+            return VibeUnityPrimitives.CreatePrimitiveWithLogging(command.name, PrimitiveType.Cube, position, rotation, scale, logCapture, "Cube", command.color);
         }
-        
+
         private static bool ExecuteAddSphereCommandWithLogging(BatchCommand command, StringBuilder logCapture)
         {
-            Vector3 position = command.position != null && command.position.Length >= 3 ? 
+            Vector3 position = command.position != null && command.position.Length >= 3 ?
                 new Vector3(command.position[0], command.position[1], command.position[2]) : Vector3.zero;
-            Vector3 rotation = command.rotation != null && command.rotation.Length >= 3 ? 
+            Vector3 rotation = command.rotation != null && command.rotation.Length >= 3 ?
                 new Vector3(command.rotation[0], command.rotation[1], command.rotation[2]) : Vector3.zero;
-            Vector3 scale = command.scale != null && command.scale.Length >= 3 ? 
+            Vector3 scale = command.scale != null && command.scale.Length >= 3 ?
                 new Vector3(command.scale[0], command.scale[1], command.scale[2]) : Vector3.one;
-                
-            return VibeUnityPrimitives.CreatePrimitiveWithLogging(command.name, PrimitiveType.Sphere, position, rotation, scale, logCapture, "Sphere");
+            return VibeUnityPrimitives.CreatePrimitiveWithLogging(command.name, PrimitiveType.Sphere, position, rotation, scale, logCapture, "Sphere", command.color);
         }
-        
+
         private static bool ExecuteAddPlaneCommandWithLogging(BatchCommand command, StringBuilder logCapture)
         {
-            Vector3 position = command.position != null && command.position.Length >= 3 ? 
+            Vector3 position = command.position != null && command.position.Length >= 3 ?
                 new Vector3(command.position[0], command.position[1], command.position[2]) : Vector3.zero;
-            Vector3 rotation = command.rotation != null && command.rotation.Length >= 3 ? 
+            Vector3 rotation = command.rotation != null && command.rotation.Length >= 3 ?
                 new Vector3(command.rotation[0], command.rotation[1], command.rotation[2]) : Vector3.zero;
-            Vector3 scale = command.scale != null && command.scale.Length >= 3 ? 
+            Vector3 scale = command.scale != null && command.scale.Length >= 3 ?
                 new Vector3(command.scale[0], command.scale[1], command.scale[2]) : Vector3.one;
-                
-            return VibeUnityPrimitives.CreatePrimitiveWithLogging(command.name, PrimitiveType.Plane, position, rotation, scale, logCapture, "Plane");
+            return VibeUnityPrimitives.CreatePrimitiveWithLogging(command.name, PrimitiveType.Plane, position, rotation, scale, logCapture, "Plane", command.color);
         }
-        
+
         private static bool ExecuteAddCylinderCommandWithLogging(BatchCommand command, StringBuilder logCapture)
         {
-            Vector3 position = command.position != null && command.position.Length >= 3 ? 
+            Vector3 position = command.position != null && command.position.Length >= 3 ?
                 new Vector3(command.position[0], command.position[1], command.position[2]) : Vector3.zero;
-            Vector3 rotation = command.rotation != null && command.rotation.Length >= 3 ? 
+            Vector3 rotation = command.rotation != null && command.rotation.Length >= 3 ?
                 new Vector3(command.rotation[0], command.rotation[1], command.rotation[2]) : Vector3.zero;
-            Vector3 scale = command.scale != null && command.scale.Length >= 3 ? 
+            Vector3 scale = command.scale != null && command.scale.Length >= 3 ?
                 new Vector3(command.scale[0], command.scale[1], command.scale[2]) : Vector3.one;
-                
-            return VibeUnityPrimitives.CreatePrimitiveWithLogging(command.name, PrimitiveType.Cylinder, position, rotation, scale, logCapture, "Cylinder");
+            return VibeUnityPrimitives.CreatePrimitiveWithLogging(command.name, PrimitiveType.Cylinder, position, rotation, scale, logCapture, "Cylinder", command.color);
         }
-        
+
         private static bool ExecuteAddCapsuleCommandWithLogging(BatchCommand command, StringBuilder logCapture)
         {
-            Vector3 position = command.position != null && command.position.Length >= 3 ? 
+            Vector3 position = command.position != null && command.position.Length >= 3 ?
                 new Vector3(command.position[0], command.position[1], command.position[2]) : Vector3.zero;
-            Vector3 rotation = command.rotation != null && command.rotation.Length >= 3 ? 
+            Vector3 rotation = command.rotation != null && command.rotation.Length >= 3 ?
                 new Vector3(command.rotation[0], command.rotation[1], command.rotation[2]) : Vector3.zero;
-            Vector3 scale = command.scale != null && command.scale.Length >= 3 ? 
+            Vector3 scale = command.scale != null && command.scale.Length >= 3 ?
                 new Vector3(command.scale[0], command.scale[1], command.scale[2]) : Vector3.one;
-                
-            return VibeUnityPrimitives.CreatePrimitiveWithLogging(command.name, PrimitiveType.Capsule, position, rotation, scale, logCapture, "Capsule");
+            return VibeUnityPrimitives.CreatePrimitiveWithLogging(command.name, PrimitiveType.Capsule, position, rotation, scale, logCapture, "Capsule", command.color);
         }
         
         private static bool ExecuteAddComponentCommandWithLogging(BatchCommand command, StringBuilder logCapture)

--- a/Editor/VibeUnityPrimitives.cs
+++ b/Editor/VibeUnityPrimitives.cs
@@ -87,29 +87,48 @@ namespace VibeUnity.Editor
         /// <summary>
         /// Creates a primitive GameObject with logging support
         /// </summary>
-        public static bool CreatePrimitiveWithLogging(string objectName, PrimitiveType primitiveType, Vector3 position, Vector3 rotation, Vector3 scale, System.Text.StringBuilder logCapture, string typeName)
+        public static bool CreatePrimitiveWithLogging(string objectName, PrimitiveType primitiveType, Vector3 position, Vector3 rotation, Vector3 scale, System.Text.StringBuilder logCapture, string typeName, string color = null)
         {
             try
             {
                 logCapture.AppendLine($"{typeName} Name: {objectName}");
                 logCapture.AppendLine($"Position: {position}");
                 logCapture.AppendLine($"Scale: {scale}");
-                
+
                 // Create the primitive GameObject
                 GameObject primitiveObject = GameObject.CreatePrimitive(primitiveType);
                 primitiveObject.name = objectName;
                 primitiveObject.transform.position = position;
                 primitiveObject.transform.rotation = Quaternion.Euler(rotation);
                 primitiveObject.transform.localScale = scale;
-                
+
+                // Apply color if specified
+                if (!string.IsNullOrEmpty(color))
+                {
+                    if (ColorUtility.TryParseHtmlString(color, out Color parsedColor))
+                    {
+                        Renderer renderer = primitiveObject.GetComponent<Renderer>();
+                        if (renderer != null)
+                        {
+                            renderer.material = new Material(renderer.sharedMaterial);
+                            renderer.material.color = parsedColor;
+                            logCapture.AppendLine($"   └─ Color: {color}");
+                        }
+                    }
+                    else
+                    {
+                        logCapture.AppendLine($"⚠️ Warning: Could not parse color: {color}");
+                    }
+                }
+
                 logCapture.AppendLine($"✅ {typeName} created successfully: {objectName}");
                 logCapture.AppendLine($"   └─ Position: {primitiveObject.transform.position}");
                 logCapture.AppendLine($"   └─ Has Collider: {primitiveObject.GetComponent<Collider>() != null}");
                 logCapture.AppendLine($"   └─ Has Renderer: {primitiveObject.GetComponent<Renderer>() != null}");
-                
+
                 // Mark scene as dirty to ensure changes are saved
                 VibeUnityScenes.MarkActiveSceneDirty();
-                
+
                 return true;
             }
             catch (System.Exception e)

--- a/Runtime/vibe-unity
+++ b/Runtime/vibe-unity
@@ -866,17 +866,22 @@ cmd_add_panel() {
 cmd_add_button() {
     local button_name=""
     local parent_name=""
+    local scene_name=""
     local button_text="Button"
     local width="160"
     local height="30"
     local anchor_preset="MiddleCenter"
     local use_session=false
-    
+
     # Parse arguments
     while [[ $# -gt 0 ]]; do
         case $1 in
             -p|--parent)
                 parent_name="$2"
+                shift 2
+                ;;
+            -s|--scene)
+                scene_name="$2"
                 shift 2
                 ;;
             -t|--text)
@@ -920,36 +925,38 @@ cmd_add_button() {
                 ;;
         esac
     done
-    
+
     # Apply session defaults if requested
     if [[ "$use_session" == "true" ]]; then
         if has_session; then
             [[ -z "$parent_name" ]] && parent_name=$(read_session "parent" "")
+            [[ -z "$scene_name" ]] && scene_name=$(read_session "scene" "")
             echo "📁 Using session defaults"
         else
             echo "⚠️  No active session found. Use 'vibe-unity start-session' to create one."
         fi
     fi
-    
+
     # Validate required arguments
     if [[ -z "$button_name" ]]; then
         echo "Error: Missing required button name"
         echo "Use 'vibe-unity add-button --help' for usage information."
         exit 1
     fi
-    
+
     echo "Unity Vibe CLI - Adding Button"
     echo "=============================="
     echo "Button Name: $button_name"
     echo "Parent: ${parent_name:-"auto-detect"}"
+    echo "Scene: ${scene_name:-"current"}"
     echo "Text: \"$button_text\""
     echo "Size: ${width}x${height}"
     echo "Anchor: $anchor_preset"
     echo "Project Path: $(get_project_path)"
     echo ""
-    
+
     # Use centralized execute_unity_command function that handles Unity detection
-    execute_unity_command "UnityVibe.Editor.CLI.AddButtonFromCommandLine" "$button_name" "$parent_name" "$button_text" "$width" "$height" "$anchor_preset"
+    execute_unity_command "UnityVibe.Editor.CLI.AddButtonFromCommandLine" "$button_name" "$parent_name" "$scene_name" "$button_text" "$width" "$height" "$anchor_preset"
     local exit_code=$?
     
     if [ $exit_code -eq 0 ]; then
@@ -966,18 +973,23 @@ cmd_add_button() {
 cmd_add_text() {
     local text_name=""
     local parent_name=""
+    local scene_name=""
     local text_content="New Text"
     local font_size="14"
     local width="200"
     local height="50"
     local anchor_preset="MiddleCenter"
     local use_session=false
-    
+
     # Parse arguments
     while [[ $# -gt 0 ]]; do
         case $1 in
             -p|--parent)
                 parent_name="$2"
+                shift 2
+                ;;
+            --scene)
+                scene_name="$2"
                 shift 2
                 ;;
             -t|--text)
@@ -1025,37 +1037,39 @@ cmd_add_text() {
                 ;;
         esac
     done
-    
+
     # Apply session defaults if requested
     if [[ "$use_session" == "true" ]]; then
         if has_session; then
             [[ -z "$parent_name" ]] && parent_name=$(read_session "parent" "")
+            [[ -z "$scene_name" ]] && scene_name=$(read_session "scene" "")
             echo "📁 Using session defaults"
         else
             echo "⚠️  No active session found. Use 'vibe-unity start-session' to create one."
         fi
     fi
-    
+
     # Validate required arguments
     if [[ -z "$text_name" ]]; then
         echo "Error: Missing required text name"
         echo "Use 'vibe-unity add-text --help' for usage information."
         exit 1
     fi
-    
+
     echo "Unity Vibe CLI - Adding Text"
     echo "============================"
     echo "Text Name: $text_name"
     echo "Parent: ${parent_name:-"auto-detect"}"
+    echo "Scene: ${scene_name:-"current"}"
     echo "Content: \"$text_content\""
     echo "Font Size: ${font_size}px"
     echo "Size: ${width}x${height}"
     echo "Anchor: $anchor_preset"
     echo "Project Path: $(get_project_path)"
     echo ""
-    
+
     # Use centralized execute_unity_command function that handles Unity detection
-    execute_unity_command "UnityVibe.Editor.CLI.AddTextFromCommandLine" "$text_name" "$parent_name" "$text_content" "$font_size" "$width" "$height" "$anchor_preset"
+    execute_unity_command "UnityVibe.Editor.CLI.AddTextFromCommandLine" "$text_name" "$parent_name" "$scene_name" "$text_content" "$font_size" "$width" "$height" "$anchor_preset"
     local exit_code=$?
     
     if [ $exit_code -eq 0 ]; then


### PR DESCRIPTION
## Summary

- Re-enables all 6 batch-mode CLI entry points that were stubbed out with `return` in v2.0, making them non-functional
- Implements `CreateSceneFromCommandLine`, `AddCanvasFromCommandLine`, `ListSceneTypesFromCommandLine`, `AddPanelFromCommandLine`, `AddButtonFromCommandLine`, `AddTextFromCommandLine`, and `ExecuteBatchFromCommandLine`
- Fixes `AddButtonFromCommandLine` and `AddTextFromCommandLine` to accept a `scene_name` argument so they can find parent UI GameObjects in the correct scene
- Fixes `VibeUnityJSONProcessor` null-check bug: `JsonUtility.FromJson` always returns a default object (never null), so the scene block was always processed even when absent â€” now checks `!string.IsNullOrEmpty(batchFile.scene.name)` instead
- Adds `color` parameter support for 3D primitives (Cube, Sphere, Plane, Cylinder, Capsule) in `CreatePrimitiveWithLogging` using `ColorUtility.TryParseHtmlString`
- Updates bash script to pass `scene_name` for `add-button` and `add-text` commands

## Test plan

- [ ] `vibe-unity list-scene-types` returns available scene types and exits 0
- [ ] `vibe-unity create-scene MyLevel --type 3D --build` creates scene file and exits 0
- [ ] `vibe-unity add-canvas MainCanvas --scene MyLevel` creates canvas in the correct scene
- [ ] `vibe-unity add-panel MyPanel --parent MainCanvas --scene MyLevel` creates panel under canvas
- [ ] `vibe-unity add-button MyButton --parent MyPanel --scene MyLevel` creates button under panel
- [ ] `vibe-unity add-text MyLabel --parent MyPanel --scene MyLevel` creates text under panel
- [ ] `vibe-unity execute-batch batch.json` processes a JSON batch file successfully
- [ ] Primitive `color` field in batch JSON applies the correct color to the object
