### PR TITLE
Code-review fixes: focus-free compile trigger, result protocol, console capture, safer exports

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Shell scripts MUST use LF line endings, or bash on Windows/WSL/git-bash fails
+# with errors like "$'\r': command not found". Force LF regardless of core.autocrlf.
+*.sh text eol=lf
+
+# Extensionless shell tools shipped by this package.
+Runtime/vibe-unity        text eol=lf
+Runtime/install-vibe-unity text eol=lf

--- a/Documentation~/CODE_REVIEW_AND_FEATURE_ROADMAP.md
+++ b/Documentation~/CODE_REVIEW_AND_FEATURE_ROADMAP.md
@@ -1,0 +1,255 @@
+# Vibe Unity — Code Review & Feature Roadmap
+
+**Date:** 2026-06-04
+**Reviewed commit:** `32c3bd1` (origin/master, includes SkyGalerio PRs #4/#5)
+**Scope:** All 17 `Editor/*.cs` files (~8,500 LOC) + shell layer (`Scripts/claude-compile-check.sh`, `Runtime/vibe-unity`, `Runtime/install-vibe-unity`, ~2,000 LOC)
+**Status:** Review only — no code changed.
+
+> ⚠️ **Note for BiteClub:** the copy installed in `bite-club` is pinned to `e6c8395` (v2.0.0), which is *behind* this review's HEAD. The CLI entry-point fixes (PR #5) and README URL fixes (PR #4) are not yet in the consumed package.
+
+---
+
+## 1. Executive Summary
+
+Vibe Unity works, but it is built on a set of fragile mechanisms that **fail silently and report success anyway**. The single most important architectural problem cuts across the entire codebase:
+
+> **The package communicates almost entirely through the Unity Editor console (`Debug.Log`), which the external agent (claude-code) cannot read. Every "insufficient feedback" finding traces back to this.** The agent only sees files on disk and shell exit codes, yet most outcomes — success, partial failure, dropped data, swallowed exceptions — are written only to the console.
+
+Layered on top of that are three recurring structural problems:
+
+1. **"Optimistic success" everywhere.** Async command-drop paths print "✅ created successfully" before Unity has done (or rejected) anything. The compile checker returns **exit 0 / SUCCESS when it observed *nothing at all*.** Setup reports success when it copied zero files. Add-component reports success when every parameter failed to apply.
+2. **Good code orphaned, lossy code live.** A rich `SceneState` export/import pipeline (components, settings, UI info, coverage analysis) exists but is **never called**; the live path is a hand-rolled, lossy JSON builder that drops every non-script component and produces a schema the importer can't even read back.
+3. **Hand-rolled where Unity/.NET already provide an API.** Window-focus to trigger compilation, regex/string JSON, `new GameObject` instead of `ObjectFactory`, manual UI construction instead of `DefaultControls`, machine-global `EditorPrefs` for project state, reflection instead of `SerializedObject`/`TypeCache`.
+
+You specifically asked about "we used a HWIN where an API would do" — see **§2.1 (compile trigger)**, which is exactly that pattern and is the highest-value fix in the codebase.
+
+---
+
+## 2. Top Findings (by priority)
+
+### P0 — Silent false success (the agent is actively misled)
+
+#### 2.1 Compilation is triggered by stealing window focus, not an API  — `claude-compile-check.sh:78-111, 398-409`
+Compilation is triggered by `AppActivate`-ing the Unity window (relying on Unity's "recompile on focus" preference) and then re-focusing "WindowsTerminal". This is the "HWIN instead of API" case. It breaks when:
+- Unity is minimized, on another desktop, or over RDP;
+- auto-refresh is disabled;
+- the terminal isn't WindowsTerminal/cmd (VS Code terminal, ConEmu, Alacritty…);
+- `Microsoft.VisualBasic.Interaction::AppActivate` simply no-ops (it frequently does).
+
+**Fix:** Trigger deterministically. The package already has a file-watcher and a status JSON. Add an editor-side `recompile`/`refresh` command file (same mechanism as scene creation, via `CompilationPipeline.RequestScriptCompilation`) and wait on the status file. Removes the focus hack entirely.
+
+#### 2.2 Compile check returns SUCCESS when it verified nothing  — `claude-compile-check.sh:379-387`
+On timeout / "no compilation logs found", the script does `output_result "SUCCESS" … "assuming all scripts are up to date"; return 0`. The whole point of the tool is to *confirm* compilation; the failure-to-observe case is reported as a clean pass. Combined with 2.1, a silently-failed trigger becomes a green light.
+**Fix:** Distinguish "verified clean" from "could not determine." Return exit 2 / `STATUS: UNKNOWN` when no compilation evidence was observed — never SUCCESS.
+
+#### 2.3 Async command-drop prints success before Unity acts  — `Runtime/vibe-unity:268-280, 593-604`; `VibeUnitySystem.cs:133-148`
+`cmd_create_scene` writes a JSON command file and immediately prints "✅ Scene created successfully", though nothing has happened yet and the result is never read back. On the editor side, `ProcessBatchFileWithLogging` returns a `bool success` that is **captured and never used** — the file is moved to `processed/` whether it succeeded or failed. There is no `failed/` directory and no per-command result file.
+**Fix:** After dropping a command file, poll for a per-request result artifact (bounded timeout) and report the real outcome. On the editor side, branch on `success`, write `<requestId>.result.json`, and route failures to a `failed/` folder.
+
+#### 2.4 Setup always reports success & permanently marks complete  — `VibeUnitySetup.cs:25-37, 39-98, 160`
+`RunSetup` sets `SETUP_COMPLETE_KEY = true` and shows "installed!" regardless of whether the package path resolved, source files existed, or copying threw (downgraded to a warning). Given 2.7 (wrong package id), this likely copies nothing while telling the user it worked.
+**Fix:** Track per-file copy results; mark complete only when the essential script copied; report what was/wasn't installed.
+
+#### 2.5 add-component reports success when parameters silently fail  — `VibeUnityJSONProcessor.cs:682-692`; `VibeUnityGameObjects.cs:341-345`
+`SetComponentParameters(...)` returns a `bool` that is discarded; the command logs "✅ added successfully" and returns true even if every parameter failed. Underneath, `ConvertParameterValue` has a bare `catch { return default }`, so `"abc"` for a float silently writes `0` and is logged as "Set X = abc".
+**Fix:** Propagate the return; log the failing param name/value/type; fail or warn the command.
+
+### P1 — Silent data loss & broken round-trips
+
+#### 2.6 Scene export & import use incompatible schemas; export drops all non-script components  — `VibeUnitySceneExporter.cs:109-211`; `VibeUnitySceneImporter.cs:44`
+The **live** exporter (`ExportSceneToJsonManually`) hand-builds JSON containing only script *type-name strings* + `position/rotation/scale` arrays. The importer deserializes the rich `SceneState` schema (`transform.localPosition`, `components[].typeName`, `hierarchyPath`, …). `JsonUtility` silently ignores the mismatched fields, so **importing a file the exporter just wrote yields empty GameObjects and still reports a high success rate.** Separately, the live export records *only* `MonoBehaviour`s — Camera, Light, MeshRenderer, Collider, Rigidbody, Canvas, Image, AudioSource are all dropped with no record. An agent reading the export to "understand" a scene is misled.
+**Fix:** Delete the manual JSON builder. Populate the existing `SceneState` model and serialize with `EditorJsonUtility.ToJson`. This fixes escaping, the schema mismatch, *and* brings the already-written coverage/settings/UI pipeline online in one move. Add a schema `version` and fail loudly when parse yields empty.
+
+#### 2.7 Wrong/duplicated package id breaks install & version detection  — `VibeUnitySetup.cs:140-142` vs `VibeUnityDocumentationUpdater.cs:125`
+One file looks for `com.vibe.unity`, the other for `com.ricoder.vibe-unity` (the real id per `package.json`). At most one is right, so script copying or version detection is broken, and the `@1.0.0` PackageCache path is version-pinned.
+**Fix:** Use `UnityEditor.PackageManager.PackageInfo.FindForAssembly(typeof(VibeUnitySetup).Assembly)` for both path and `.version`. Removes all hardcoded ids and the package.json regex parse.
+
+#### 2.8 Documentation updater can silently truncate user content  — `VibeUnityDocumentationUpdater.cs:286-289`
+If the start marker exists but the end marker is missing (truncated/edited CLAUDE.md), the code does `Substring(0, sectionStart) + newSection`, **deleting everything after the start marker** with no backup or warning.
+**Fix:** If the end marker is missing, warn and refuse (or append fresh); write a `.bak` before rewriting.
+
+#### 2.9 Two compilation trackers race on the same file  — `VibeUnitySystem.cs:415-582` vs `VibeUnityCompilationController.cs:85-251`
+`VibeUnitySystem` polls `EditorApplication.isCompiling` every frame and writes `compilation.json`; `VibeUnityCompilationController` uses the correct event-driven `CompilationPipeline.compilationStarted/Finished` and *also* writes `compilation.json` — with a different schema. They race.
+**Fix:** Delete the polling tracker; keep the event-driven one as the single status writer.
+
+#### 2.10 Settings save failure reported as success in the window  — `VibeUnitySettings.cs:43-60`; `VibeUnitySettingsWindow.cs:108-111, 171-185`
+`SaveSettings` swallows write failures (only `Debug.LogError`); the "Save Settings" button unconditionally shows "Settings saved!". A read-only `.vibe-unity` dir => user believes settings persisted.
+**Fix:** Return `bool` from `SaveSettings`; show success only on true, error otherwise.
+
+#### 2.11 Project-global EditorPrefs for project-scoped state  — `VibeUnitySetup.cs:14`; `VibeUnityDocumentationUpdater.cs:23-42`
+`SETUP_COMPLETE_KEY = "VibeUnity_SetupComplete"` is machine-global and unqualified, so the **first** project to run setup on a machine marks setup "complete" for every other project — new projects silently skip script copying.
+**Fix:** Key by project path/hash (a `GetProjectHash()` already exists) or store in the project-local settings JSON.
+
+### P2 — Fragility where a clean API exists
+
+| # | Finding | Location | Fix |
+|---|---------|----------|-----|
+| 2.12 | JSON parsed/emitted via regex + string interpolation; corrupts on `"` `\` newlines (and compiler errors contain all three) | `VibeUnityHttpServer.cs:133-176`; `VibeUnitySystem.cs:484-542`; `Runtime/vibe-unity:54-141` | Use `JsonUtility`/Newtonsoft (ships as `com.unity.nuget.newtonsoft-json`); JSON-escape shell heredocs or use `jq` |
+| 2.13 | `JsonUtility` can't represent the documented schema (no root arrays, no presence detection, unknown fields dropped) — the giant flat `BatchCommand` union is a workaround | `VibeUnityJSONProcessor.cs:45, 829-898` | Move command parsing to Newtonsoft `JObject`; per-verb typed payloads; validate keys |
+| 2.14 | No JSON schema validation — misspelled fields (`colour`, `widthPx`) silently dropped, defaults used | `VibeUnityJSONProcessor.cs:45` + executors | Validate keys per `action`; warn on unrecognized keys |
+| 2.15 | `new GameObject` / `CreatePrimitive` bypass `ObjectFactory` (no Undo, no auto-dirty, manual scene registration) | `VibeUnityGameObjects.cs:362`; `VibeUnityUI.cs`; `VibeUnityPrimitives.cs` | Use `ObjectFactory.CreateGameObject/CreatePrimitive/AddComponent` + `Undo.RegisterCreatedObjectUndo` |
+| 2.16 | UI hand-built; Button has no sprite/transition, ScrollView creates **no scrollbars** but sets visibility on null refs | `VibeUnityUI.cs:213-433` | Use `UnityEngine.UI.DefaultControls.Create*` (+ TMP variants) |
+| 2.17 | Reflection (`GetFields`/`GetValue` + string round-trip) for component props; loses precision, misses `[SerializeField] private`, breaks on comma-decimal locales | `VibeUnitySceneExporter.cs:757-801`; `VibeUnitySceneImporter.cs:412-511` | Use `SerializedObject`/`SerializedProperty`; `CultureInfo.InvariantCulture`; store floats as JSON numbers |
+| 2.18 | Component type lookup scans every assembly + namespace guessing | `VibeUnityGameObjects.cs:181-209` | `UnityEditor.TypeCache.GetTypesDerivedFrom<Component>()` |
+| 2.19 | Positional CLI arg parsing + unguarded `int/float/bool.Parse` (throws out of reflection-invoked entry point, bypassing the `Exit(1)` error path) | `VibeUnityCLI.cs:445-681` | Named-flag dictionary + `TryParse`; or deprecate per-verb CLI in favor of JSON batch |
+| 2.20 | `projectHash = Math.Abs(path.GetHashCode())` — not stable across runs; throws on `int.MinValue` | `VibeUnityCompilationController.cs:67` | Stable hash (MD5/SHA over UTF-8 bytes) |
+| 2.21 | Hardcoded user log path `…/Users/matth/…` + `/mnt/c` (wrong on git-bash `/c/…` and every other user); `stat -c%s` is GNU-only | `claude-compile-check.sh:16, 249` | Derive via `$LOCALAPPDATA`/`wslpath`/`cygpath`; `wc -c < file` for size |
+| 2.22 | WSL→Windows path conversion only rewrites `/mnt/c` (breaks `/mnt/d`, UNC, git-bash) | `Runtime/vibe-unity:30-36` | `wslpath -w` / `cygpath -w` with fallback |
+| 2.23 | Render-pipeline detected by `GetType().Name.Contains("Universal")`, duplicated 3× | `VibeUnityCLI.cs:157-163`; `VibeUnityScenes.cs:106-113, 313-320` | One helper; `GraphicsSettings.currentRenderPipeline is UniversalRenderPipelineAsset` |
+| 2.24 | `chmod` started fire-and-forget, exit code never checked (×2); also gated on `Platform == Unix`, so never runs under Windows-Unity-in-WSL | `VibeUnitySetup.cs:63-66`; `VibeUnitySystem.cs:746-758` | Check `ExitCode`; reconsider platform gate |
+| 2.25 | Broad `*Unity*` process kill also kills Unity Hub / ShaderCompiler / Licensing | `Runtime/vibe-unity:1205-1209` | Scope to exact `Unity` + known children; exclude Hub |
+
+### P3 — Other notable correctness issues
+- **Empty/blanket catches** that return null/skip with no log: `VibeUnitySystem.cs:366-369`, `VibeUnitySceneImporter.cs:169-258, 507-510`, `VibeUnityGameObjects.cs:341-345`.
+- **Ignored return values:** `FileStream.Read` byte count (`VibeUnitySystem.cs:511`), `SaveScene`/`NewScene`/`OpenScene` bools (`VibeUnitySceneImporter.cs:65-150`).
+- **Divide-by-zero / NaN** in coverage & success-rate reports when component/object counts are zero: `VibeUnitySceneExporter.cs:1123-1125`, `VibeUnitySceneImporter.cs:143-153`.
+- **`success = !result.StartsWith("Error:")`** — real failures ("Failed to create scene", "Unknown command") don't start with "Error:" and report `success:true`: `VibeUnityHttpServer.cs:157`.
+- **Exit code 3 overloaded** — documented "script error" but also returned to mean "retry needed": `claude-compile-check.sh:48, 358, 382`.
+- **Literal `\n` in error output** — accumulated with `\n` then `echo`'d without `-e`, so multi-error blocks collapse onto one line: `claude-compile-check.sh:175-201, 60-66`.
+- **Emoji as status markers** (`✅❌⚠️`) throughout logs the agent greps — contradicts CLAUDE.md's own "no graphic Unicode" rule and is encoding-fragile; the documented tokens ("STATUS: SUCCESS") aren't consistently emitted.
+- **`install-vibe-unity` self-test** runs `vibe-unity --version` (a no-op echo, always exit 0) and prints "working correctly" even when Unity is absent: `install-vibe-unity:63-72`.
+
+---
+
+## 3. Cross-cutting recommendation: a real result protocol
+
+Almost every P0/P1 feedback gap closes with **one** change: for every consumed command, write a machine-readable result the agent can poll, keyed by a `requestId` (the field already exists on `CompileCommand`).
+
+```
+.vibe-unity/results/<requestId>.json
+{
+  "requestId": "…",
+  "action": "create-scene",
+  "status": "SUCCESS | PARTIAL | FAILURE",
+  "message": "…",
+  "errors":   [ { "command": 3, "message": "…" } ],
+  "warnings": [ … ],
+  "produced": [ "Assets/Scenes/Foo.unity" ],
+  "durationMs": 1234,
+  "schemaVersion": 1
+}
+```
+
+Pair it with a `--json` mode on `claude-compile-check.sh` emitting the already-parsed `{status, errorCount, warnings, errors:[{file,line,col,code,message}]}` instead of scraped text. This removes the `\n`/`|`/emoji parsing hazards and the optimistic-success paths in one stroke.
+
+---
+
+## 4. Feature Roadmap — capturing what Unity's MCP exposes
+
+Unity's official MCP (the toolset we saw wired into claude-code) is the natural feature target. Below is the **full capability surface**, mapped to vibe-unity's current state, so we can pick what to build. Legend: ✅ have · 🟡 partial/orphaned · ❌ missing.
+
+### 4.1 Editor lifecycle & state — `Unity_ManageEditor`
+Play / Pause / Stop, GetState, GetProjectRoot, GetWindows, GetActiveTool, **GetSelection**, GetPrefabStage, Add/Remove/Get **Tags** & **Layers**.
+- vibe-unity: ❌ none. No play-mode control (`OnPlayModeChanged` is an empty stub, `VibeUnityHttpServer.cs:97-100`), no selection, no tag/layer management.
+- **Build:** `enter-playmode`/`exit-playmode` (`EditorApplication.isPlaying`), report `playModeStateChanged`; `get-selection`/`set-selection`; `add-tag`/`add-layer`. Play-mode control directly serves "play 5 minutes to see if you can beat it" validation.
+
+### 4.2 Console logs — `Unity_GetConsoleLogs` / `Unity_ReadConsole`  ← biggest gap
+Read runtime errors/warnings/`Debug.Log` with severity + stack traces.
+- vibe-unity: ❌ none. No `Application.logMessageReceivedThreaded` hook anywhere. The agent cannot see *any* runtime output.
+- **Build:** subscribe to `Application.logMessageReceivedThreaded`, buffer to a rolling JSON file with `{severity, message, stackTrace, time}`, expose a `get-logs` reader. **This is Unity MCP's signature feature and the highest-value single addition.**
+
+### 4.3 GameObject & component management — `Unity_ManageGameObject`
+Create / find / modify / delete GameObjects; add/remove components; **set serialized properties**; reparent; query hierarchy.
+- vibe-unity: 🟡 create/add only (Canvas, Panel, Button, Text, ScrollView, primitives, `add-component`). No delete/rename/reparent/move/set-active, no remove-component, no read-back. (The building blocks — `FindInActiveScene`, `GetPath`, `ListAvailable` — exist but aren't exposed as commands.)
+- **Build:** mutation verbs (`delete`, `rename`, `reparent`, `set-transform`, `set-active`, `remove-component`, generic `set-property` via `SerializedProperty`); **query verbs** (`get-hierarchy`, `find-object`, `get-component`, `exists`) returning structured JSON so the agent can verify its own work.
+
+### 4.4 Scene management — `Unity_ManageScene`
+- vibe-unity: 🟡 create/open/save + lossy export/import (see 2.6). `2D/3D/URP/HDRP` scene types are advertised but silently fall back to Empty/DefaultGameObjects.
+- **Build:** round-trip-safe export via `SceneState`; multi-scene/additive support; honor (or stop advertising) the scene-type templates via the `SceneTemplate` API.
+
+### 4.5 Assets — `Unity_ManageAsset`, `Unity_ImportExternalModel`, `Unity_AssetGeneration_*`
+Asset CRUD, external model import, AI asset generation + model listing.
+- vibe-unity: ❌ none. No prefab instantiation, no material/sprite/texture assignment, no asset creation.
+- **Build (high value for scene authoring):** `instantiate-prefab` (`PrefabUtility.InstantiatePrefab` + `AssetDatabase.LoadAssetAtPath`), `assign-material`/`assign-sprite` by asset path, `create-prefab`. Also: capture prefab *connections* on export (currently flattened — 2.6 sibling issue).
+
+### 4.6 Scripts — `Unity_CreateScript` / `ManageScript` / `ApplyTextEdits` / `ValidateScript` / `DeleteScript`
+- vibe-unity: ❌ none (claude-code edits scripts directly on disk, so lower priority — but `ValidateScript`-style pre-compile validation could be useful).
+
+### 4.7 Menu items & commands — `Unity_ManageMenuItem` / `Unity_RunCommand`
+- vibe-unity: ❌ none. `EditorApplication.ExecuteMenuItem("…")` would expose every menu command (build, lighting bake, etc.) for almost no code.
+- **Build:** `execute-menu-item` verb.
+
+### 4.8 Testing & build — (Unity MCP runs via menu/commands; we'd back it directly)
+- vibe-unity: ❌ none.
+- **Build (maps directly to CLAUDE.md's definition of done):**
+  - `run-tests` via `UnityEditor.TestTools.TestRunner.Api.TestRunnerApi` (EditMode/PlayMode), results to JSON — serves "does it pass / is it done."
+  - `build` via `BuildPipeline.BuildPlayer` for Android/iOS — the literal "done = published on Play Store / App Store" goal.
+
+### 4.9 Visual capture — `Unity_Camera_Capture` / `SceneView_Capture2DScene` / `CaptureMultiAngleSceneView`
+Screenshot game camera & scene view (multi-angle).
+- vibe-unity: ❌ none.
+- **Build:** `capture-game-view` / `capture-scene-view` via `ScriptableRenderContext`/`Camera.Render` to a PNG the agent can read. Lets the agent *see* a level it built — very high value for "is this level fun/correct."
+
+### 4.10 Profiler — `Unity_Profiler_*` (large suite)
+GC allocations (frame/range/overall), time samples (self/top/bottom-up), frame analysis, related-sample trees.
+- vibe-unity: ❌ none.
+- **Build (v2):** `ProfilerRecorder` API to capture frame timing/GC and write summaries — relevant for mobile perf, but lower priority than logs/tests/capture.
+
+### 4.11 Project introspection — `GetProjectData` / `Grep` / `FindInFile` / `GetSha` / `ListResources` / `ReadResource` / `PackageManager_*`
+- vibe-unity: 🟡 has its own project/hierarchy exporters (RICoder tools) and package-version reading (currently broken — 2.7). Grep/find are better served by claude-code's native file tools.
+
+### 4.12 Suggested build order
+1. **Console log capture** (4.2) + **result protocol** (§3) — unblocks the agent's blindness.
+2. **Query/inspect verbs** (4.3) — lets the agent verify its own work.
+3. **Capture game/scene view** (4.9) — lets the agent *see* results.
+4. **run-tests + execute-menu-item** (4.7/4.8) — automated validation.
+5. **GameObject mutation verbs + prefab/material assignment** (4.3/4.5) — real authoring.
+6. **Play-mode control** (4.1), **build automation** (4.8), **profiler** (4.10) — v2.
+
+---
+
+## 5. Appendix — file-by-file finding index
+
+- **VibeUnitySystem.cs** — 2.3, 2.9; empty catch (366), ignored `Read` (511), unchecked chmod (746).
+- **VibeUnityHttpServer.cs** — entire server disabled (27-95); regex JSON + string responses (133-176); prefix-sniffed success (157); busy-wait `Thread.Sleep` (152-174).
+- **VibeUnityCompilationController.cs** — 2.9; `GetHashCode` project id (67); `UpdateShortcuts` no-op logs success (416-423); `clear-cache` overstates (329-331).
+- **VibeUnityCLI.cs** — 2.19; render-pipeline string match (157-163); dead `logCapture` overload (699-702); scene-type list disagreements (141-166 vs 385-419).
+- **VibeUnityJSONProcessor.cs** — 2.5, 2.13, 2.14; abort-on-first-failure, no result manifest (80-98); empty-vs-absent field conflation (296+); emoji status markers.
+- **VibeUnitySceneExporter.cs** — 2.6; manual JSON builder + weak escaper (109-279); reflection props (757-801); orphaned rich pipeline (284, 553, 1026-1192).
+- **VibeUnitySceneImporter.cs** — 2.6; wrong-schema deserialize (44); ignored save/new/open bools (65-150); blanket settings catch (169-258); NaN success rate (143-153).
+- **VibeUnitySceneState.cs** — schema is the *correct* target model; fields (`worldCamera`, tag/layer/static/sibling) never populated by live export.
+- **VibeUnityScenes.cs** — advertised 2D/URP/HDRP types are no-ops (302-325); render-pipeline string match (106-113, 313-320).
+- **VibeUnityGameObjects.cs** — 2.5, 2.15, 2.17, 2.18; silent `ConvertParameterValue` (341-345); missing-param warning lost when `logCapture` null (259); no dirty/save on `CreateEmptyGameObject`/`AddComponent`.
+- **VibeUnityPrimitives.cs** — 2.15; no material/layer/tag/static; color handling inconsistent between the two entry points.
+- **VibeUnityUI.cs** — 2.16; ScrollView scrollbars never created (377-378); only 5 element types; no layout groups; 9-anchor only (no stretch).
+- **VibeUnityMenu.cs** — global EditorPrefs flags (13-23); CLI features advertised that are disabled (486); touch-and-report-initiated (349-378).
+- **VibeUnitySettings.cs** — 2.10; corrupt-file not healed on load (65-96).
+- **VibeUnitySettingsWindow.cs** — 2.10; shortcuts UI implies live rebind but `[MenuItem]` is compile-time (87-164).
+- **VibeUnitySetup.cs** — 2.4, 2.7, 2.11, 2.24; `.gitignore` substring check (114); stale welcome dialog referencing disabled CLI.
+- **VibeUnityDocumentationUpdater.cs** — 2.7, 2.8, 2.11; regex package.json parse (130); null version swallowed (121-138).
+- **claude-compile-check.sh** — 2.1, 2.2, 2.21; exit-3 overload; literal `\n`; no `set -euo pipefail`; retry off-by-one (355-415); `current_size` scope (348); stale-lock not detected (130-154).
+- **Runtime/vibe-unity** — 2.3, 2.12, 2.22, 2.25; `$?` after command-substitution (169-174); errors to stdout not stderr; unused `execute_via_http`.
+- **Runtime/install-vibe-unity** — no-op self-test reports success (63-72); naive Unity glob via `command -v` (38-39).
+
+---
+
+## 6. Test Rig Review — `D:\repos\vibe-unity-testrig`
+
+**Reviewed commit:** `43caccc` (origin/main). A real URP Unity project that consumes `com.ricoder.vibe-unity` via the same git URL and exercises it through `run-package-tests.sh` plus helper scripts.
+
+### 6.1 Positive
+- **The historical "0 errors even when errors exist" bug is fixed.** `VibeUnityCompilationController.cs:125-196` now counts real `CompilerMessage[]` via `CompilationPipeline.assemblyCompilationFinished` with an `EditorUtility.scriptCompilationFailed` fallback. The old broken reflection approach (documented in `SESSION-NOTES.md`) is gone.
+- `run-package-tests.sh` has a genuine pass/fail counter and a meaningful exit code on TEST 1 and TEST 4.
+
+### 6.2 The harness can't reliably fail — `run-package-tests.sh`
+- **TEST 3 (scene creation) can never fail the suite.** When Unity isn't running / log missing / status ambiguous, it prints a yellow warning and does **not** increment `TESTS_FAILED` (`run-package-tests.sh:135-149`); the scene-file check likewise only warns. TEST 3 is informational only.
+- That leaves **TEST 1 (valid compile) and TEST 4 (cleanup)** as the only hard assertions. **TEST 2 (error script must fail)** is real but hostage to the focus-hack trigger (§2.1): if the trigger silently no-ops, the package's SUCCESS-on-no-evidence path (§2.2) lets a genuine compile error pass undetected.
+- Net: the suite can print **"✓ All tests passed! Package is ready for release"** having effectively verified one happy-path compile. False confidence for a release gate.
+- **Fix:** make TEST 3 a hard assertion (fail, not warn, when Unity is down or the scene file is absent), or explicitly gate the suite on "requires live Unity."
+
+### 6.3 Script drift & dead code
+- **Five compile-check scripts** coexist: `claude-compile-check-simple.sh` (62), `-v2.sh` (339), `-v3.sh` (207), `-v4.sh` (200), and `claude-compile-check.sh` (472). The "current" 472-line copy **diverges from the package's canonical 425-line `Scripts/claude-compile-check.sh`** — a fix in the package won't reach the testrig.
+  - **Fix:** delete the four variants; have the testrig invoke the package's script (symlink / copy-at-install) rather than forking it.
+- **`test-workflow.sh` is dead.** It targets `/mnt/c/repos/vibe-unity-testrig/.vibe-commands/test-scene-creation.json`, but the repo is at `D:\repos` (not `/mnt/c/repos`), the live dir is `.vibe-unity/commands` (not `.vibe-commands`), and `.vibe-commands/` does not exist. It also re-implements the window-focus hack and the hardcoded `Users/matth` log path. It cannot run.
+  - **Fix:** remove it, or rewrite against the real `.vibe-unity/commands` layout + the deterministic trigger from §2.1.
+
+### 6.4 Repo hygiene — committed runtime artifacts + misdirected `.gitignore`
+- **Generated/ephemeral state is tracked in git:** `.vibe-unity/compile-commands/compile-request-75AFA5E1-…json`, `.vibe-unity/compile-status/compile-status-error-test-…json`, `compilation/current-status.json`, `compilation/last-errors.json`, `status/compilation.json`, and **`compilation/project-hash.txt`**. The committed project hash is especially harmful given `SESSION-NOTES.md` documents cross-machine hash mismatches (`BBECC349` vs `5E88DFAB`).
+- **`.gitignore` excludes `.vibe-commands/`** — a directory that doesn't exist — **but not** the `.vibe-unity/` runtime subdirs that actually hold generated state. The ignore rules predate the current directory layout (same drift as the scripts).
+  - **Fix:** `git rm --cached` the runtime artifacts; ignore `.vibe-unity/{compilation,compile-commands,compile-status,status}/` and `project-hash.txt`; keep `vibe-unity-settings.json` if intended as config.
+- **`SESSION-NOTES.md`** is stale (dated 2025-08-08, describes since-resolved debugging). Mark as historical to avoid misleading future readers.
+
+### 6.5 Testrig fix priority
+1. **6.2** — TEST 3 (and the TEST 2 trigger dependency) so the suite can actually gate a release.
+2. **6.3** — collapse the five scripts to one sourced from the package; delete the dead workflow script.
+3. **6.4** — untrack runtime artifacts and fix `.gitignore`.

--- a/Editor/VibeUnityCompilationController.cs
+++ b/Editor/VibeUnityCompilationController.cs
@@ -228,21 +228,14 @@ namespace VibeUnity.Editor
                 
                 string json = JsonUtility.ToJson(statusData, true);
                 File.WriteAllText(currentStatusFile, json);
-                
-                // Also update the legacy compilation.json for backward compatibility
-                string legacyFile = Path.Combine(Directory.GetParent(compilationDir).FullName, "status", "compilation.json");
-                if (Directory.Exists(Path.GetDirectoryName(legacyFile)))
-                {
-                    var legacyData = new
-                    {
-                        status = status == "success" ? "complete" : status,
-                        started = status == "compiling" ? (long?)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() : null,
-                        startedMs = status == "compiling" ? (long?)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() : null,
-                        ended = status != "compiling" ? DateTimeOffset.UtcNow.ToString("yyyy-MM-dd'T'HH:mm:ss.fff'Z'") : null,
-                        endedMs = status != "compiling" ? DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() : 0
-                    };
-                    File.WriteAllText(legacyFile, JsonUtility.ToJson(legacyData));
-                }
+
+                // NOTE: status/compilation.json is intentionally NOT written here.
+                // VibeUnitySystem's compilation tracker owns that file and writes it
+                // with an exclusive file lock during compilation (the compile-check
+                // script relies on that lock for its "compiling" detection). The
+                // previous write here both raced with that writer and was broken -
+                // JsonUtility cannot serialize an anonymous type, so it produced "{}".
+                // This controller owns the richer current-status.json / last-errors.json.
             }
             catch (Exception e)
             {

--- a/Editor/VibeUnityDocumentationUpdater.cs
+++ b/Editor/VibeUnityDocumentationUpdater.cs
@@ -98,10 +98,21 @@ Vibe Unity enables claude-code integration for Unity scene creation and project 
                 
                 // Generate new documentation section
                 string newSection = GenerateDocumentationSection(packageVersion);
-                
+
                 // Update the file
                 string updatedContent = UpdateDocumentationSection(existingContent, newSection);
-                
+
+                // If the updater declined to modify (e.g. malformed markers), leave
+                // the file untouched rather than risk destroying user content.
+                if (ReferenceEquals(updatedContent, existingContent) || updatedContent == existingContent)
+                {
+                    return false;
+                }
+
+                // Defensive backup before overwriting the user's CLAUDE.md.
+                try { File.Copy(claudeMdPath, claudeMdPath + ".bak", true); }
+                catch (Exception be) { Debug.LogWarning($"[VibeUnity] Could not write CLAUDE.md.bak: {be.Message}"); }
+
                 // Write back to file
                 File.WriteAllText(claudeMdPath, updatedContent);
                 
@@ -122,17 +133,18 @@ Vibe Unity enables claude-code integration for Unity scene creation and project 
         {
             try
             {
-                string packageJsonPath = Path.Combine(Application.dataPath, "..", "Packages", "com.ricoder.vibe-unity", "package.json");
-                if (!File.Exists(packageJsonPath))
-                    return null;
-                    
-                string packageJson = File.ReadAllText(packageJsonPath);
-                var match = Regex.Match(packageJson, @"""version"":\s*""([^""]+)""");
-                
-                return match.Success ? match.Groups[1].Value : null;
+                // Resolve via the package manager rather than a hardcoded path + regex,
+                // which broke when the package id/location differed from the assumption.
+                var pkg = UnityEditor.PackageManager.PackageInfo.FindForAssembly(typeof(VibeUnityDocumentationUpdater).Assembly);
+                if (pkg != null && !string.IsNullOrEmpty(pkg.version))
+                    return pkg.version;
+
+                Debug.LogWarning("[VibeUnity] Could not resolve package version via PackageInfo.");
+                return null;
             }
-            catch
+            catch (Exception e)
             {
+                Debug.LogWarning($"[VibeUnity] Error resolving package version: {e.Message}");
                 return null;
             }
         }
@@ -284,8 +296,13 @@ Vibe Unity enables claude-code integration for Unity scene creation and project 
                 }
                 else
                 {
-                    // Section start found but no end marker - replace from start marker to end
-                    return existingContent.Substring(0, sectionStart) + newSection;
+                    // Section start found but NO end marker: the file is malformed.
+                    // Previously this truncated everything after the start marker,
+                    // silently destroying any user content below it. Refuse instead
+                    // and leave the file untouched (caller skips the write).
+                    Debug.LogWarning("[VibeUnity] CLAUDE.md has a Vibe Unity start marker but no end marker; " +
+                                     "refusing to modify to avoid deleting user content. Fix or remove the marker.");
+                    return existingContent;
                 }
             }
             else

--- a/Editor/VibeUnityGameObjects.cs
+++ b/Editor/VibeUnityGameObjects.cs
@@ -256,12 +256,16 @@ namespace VibeUnity.Editor
                     return true;
                 }
 
-                logCapture?.AppendLine($"   └─ Warning: Parameter '{param.name}' not found on component");
+                logCapture?.AppendLine($"   - Warning: Parameter '{param.name}' not found on component");
+                Debug.LogWarning($"[VibeUnity] Parameter '{param.name}' not found on {component.GetType().Name}");
                 return false;
             }
             catch (System.Exception e)
             {
-                logCapture?.AppendLine($"   └─ Error setting parameter '{param.name}': {e.Message}");
+                // Surface the failure even when no log buffer was supplied, so the
+                // caller can no longer silently believe the parameter was applied.
+                logCapture?.AppendLine($"   - Error setting parameter '{param.name}': {e.Message}");
+                Debug.LogWarning($"[VibeUnity] Failed to set '{param.name}' = '{param.value}' on {component.GetType().Name}: {e.Message}");
                 return false;
             }
         }
@@ -271,78 +275,60 @@ namespace VibeUnity.Editor
         /// </summary>
         private static object ConvertParameterValue(string value, string paramType, System.Type targetType)
         {
-            try
-            {
-                // Handle null/empty values
-                if (string.IsNullOrEmpty(value))
-                {
-                    return targetType.IsValueType ? System.Activator.CreateInstance(targetType) : null;
-                }
+            // NOTE: this intentionally THROWS on malformed input instead of silently
+            // returning a type default. The caller (SetComponentParameter) catches it,
+            // logs, and returns false — so a bad value can no longer be reported as a
+            // successful set. Uses InvariantCulture so comma-decimal locales don't
+            // mis-parse "1.5" or collide with the comma delimiter.
+            var inv = System.Globalization.CultureInfo.InvariantCulture;
 
-                // Handle common types
-                if (targetType == typeof(int))
-                    return int.Parse(value);
-                if (targetType == typeof(float))
-                    return float.Parse(value);
-                if (targetType == typeof(double))
-                    return double.Parse(value);
-                if (targetType == typeof(bool))
-                    return bool.Parse(value);
-                if (targetType == typeof(string))
-                    return value;
-
-                // Handle Unity types
-                if (targetType == typeof(Vector3))
-                {
-                    string[] parts = value.Split(',');
-                    if (parts.Length >= 3)
-                    {
-                        return new Vector3(
-                            float.Parse(parts[0].Trim()),
-                            float.Parse(parts[1].Trim()),
-                            float.Parse(parts[2].Trim())
-                        );
-                    }
-                }
-
-                if (targetType == typeof(Vector2))
-                {
-                    string[] parts = value.Split(',');
-                    if (parts.Length >= 2)
-                    {
-                        return new Vector2(
-                            float.Parse(parts[0].Trim()),
-                            float.Parse(parts[1].Trim())
-                        );
-                    }
-                }
-
-                if (targetType == typeof(Color))
-                {
-                    Color color;
-                    if (ColorUtility.TryParseHtmlString(value, out color))
-                        return color;
-
-                    string[] parts = value.Split(',');
-                    if (parts.Length >= 3)
-                    {
-                        return new Color(
-                            float.Parse(parts[0].Trim()),
-                            float.Parse(parts[1].Trim()),
-                            float.Parse(parts[2].Trim()),
-                            parts.Length > 3 ? float.Parse(parts[3].Trim()) : 1f
-                        );
-                    }
-                }
-
-                // Try generic conversion
-                return System.Convert.ChangeType(value, targetType);
-            }
-            catch
-            {
-                // Return default value for type if conversion fails
+            // Empty -> type default (explicitly allowed).
+            if (string.IsNullOrEmpty(value))
                 return targetType.IsValueType ? System.Activator.CreateInstance(targetType) : null;
+
+            if (targetType == typeof(int))    return int.Parse(value, inv);
+            if (targetType == typeof(float))  return float.Parse(value, inv);
+            if (targetType == typeof(double)) return double.Parse(value, inv);
+            if (targetType == typeof(bool))   return bool.Parse(value);
+            if (targetType == typeof(string)) return value;
+
+            if (targetType == typeof(Vector3))
+            {
+                string[] parts = value.Split(',');
+                if (parts.Length < 3)
+                    throw new System.FormatException($"Vector3 needs 3 comma-separated values, got '{value}'");
+                return new Vector3(
+                    float.Parse(parts[0].Trim(), inv),
+                    float.Parse(parts[1].Trim(), inv),
+                    float.Parse(parts[2].Trim(), inv));
             }
+
+            if (targetType == typeof(Vector2))
+            {
+                string[] parts = value.Split(',');
+                if (parts.Length < 2)
+                    throw new System.FormatException($"Vector2 needs 2 comma-separated values, got '{value}'");
+                return new Vector2(
+                    float.Parse(parts[0].Trim(), inv),
+                    float.Parse(parts[1].Trim(), inv));
+            }
+
+            if (targetType == typeof(Color))
+            {
+                if (ColorUtility.TryParseHtmlString(value, out Color color))
+                    return color;
+                string[] parts = value.Split(',');
+                if (parts.Length < 3)
+                    throw new System.FormatException($"Color needs an html string or 3-4 comma values, got '{value}'");
+                return new Color(
+                    float.Parse(parts[0].Trim(), inv),
+                    float.Parse(parts[1].Trim(), inv),
+                    float.Parse(parts[2].Trim(), inv),
+                    parts.Length > 3 ? float.Parse(parts[3].Trim(), inv) : 1f);
+            }
+
+            // Generic fallback (throws on failure, which the caller handles).
+            return System.Convert.ChangeType(value, targetType, inv);
         }
 
 

--- a/Editor/VibeUnityJSONProcessor.cs
+++ b/Editor/VibeUnityJSONProcessor.cs
@@ -678,13 +678,20 @@ namespace VibeUnity.Editor
                     return false;
                 }
                 
-                // Set component parameters if provided
+                // Set component parameters if provided. Surface failures instead of
+                // discarding the result and reporting unconditional success.
                 if (command.parameters != null && command.parameters.Length > 0)
                 {
-                    VibeUnityGameObjects.SetComponentParameters(addedComponent, command.parameters, logCapture);
+                    bool paramsOk = VibeUnityGameObjects.SetComponentParameters(addedComponent, command.parameters, logCapture);
+                    if (!paramsOk)
+                    {
+                        logCapture.AppendLine($"FAIL: one or more parameters on '{componentTypeName}' could not be applied (see above)");
+                        VibeUnityScenes.MarkActiveSceneDirty();
+                        return false;
+                    }
                 }
-                
-                logCapture.AppendLine($"✅ Component '{componentTypeName}' added successfully to '{targetName}'");
+
+                logCapture.AppendLine($"SUCCESS: Component '{componentTypeName}' added to '{targetName}'");
                 
                 // Mark scene as dirty to ensure changes are saved
                 VibeUnityScenes.MarkActiveSceneDirty();

--- a/Editor/VibeUnityJSONProcessor.cs
+++ b/Editor/VibeUnityJSONProcessor.cs
@@ -142,9 +142,75 @@ namespace VibeUnity.Editor
             }
             finally
             {
-                // Save the log file
+                // Save the human-readable log...
                 SaveLogFile(jsonFilePath, logCapture, overallSuccess);
+                // ...and a machine-readable result the external agent can poll.
+                SaveResultFile(jsonFilePath, overallSuccess, logCapture);
             }
+        }
+
+        /// <summary>
+        /// Writes a structured, machine-readable result next to the logs so the
+        /// external agent can determine the outcome deterministically instead of
+        /// scraping free-text/emoji log lines.
+        /// </summary>
+        private static void SaveResultFile(string jsonFilePath, bool success, StringBuilder logCapture)
+        {
+            try
+            {
+                string commandsDir = Path.GetDirectoryName(jsonFilePath); // .vibe-unity/commands
+                string resultsDir = Path.Combine(commandsDir, "results");
+                Directory.CreateDirectory(resultsDir);
+
+                // Best-effort extraction of failure lines, ASCII-only (no emoji
+                // literals in source - those are fragile). Only when the batch failed;
+                // a successful batch reports no errors.
+                var errors = new System.Collections.Generic.List<string>();
+                if (!success)
+                {
+                    foreach (var raw in logCapture.ToString().Split('\n'))
+                    {
+                        string t = raw.Trim();
+                        if (t.Length == 0) continue;
+                        string lower = t.ToLowerInvariant();
+                        if (lower.Contains("success")) continue; // skip success lines
+                        if (lower.Contains("error") || lower.Contains("fail") ||
+                            lower.Contains("exception") || lower.Contains("not found") ||
+                            lower.Contains("fatal") || lower.Contains("could not"))
+                        {
+                            errors.Add(StripLeadingNonAscii(t));
+                        }
+                    }
+                }
+
+                var result = new BatchResult
+                {
+                    schemaVersion = 1,
+                    sourceFile = Path.GetFileName(jsonFilePath),
+                    success = success,
+                    status = success ? "SUCCESS" : "FAILURE",
+                    timestampUtc = System.DateTime.UtcNow.ToString("o"),
+                    message = success ? "Batch completed." : "Batch failed; see corresponding .log.",
+                    errors = errors.ToArray()
+                };
+
+                string json = JsonUtility.ToJson(result, true);
+                string baseName = Path.GetFileNameWithoutExtension(jsonFilePath);
+                File.WriteAllText(Path.Combine(resultsDir, baseName + ".result.json"), json);
+                File.WriteAllText(Path.Combine(resultsDir, "latest.result.json"), json);
+            }
+            catch (System.Exception e)
+            {
+                Debug.LogWarning($"[VibeUnity] Failed to write result file: {e.Message}");
+            }
+        }
+
+        /// <summary>Drops leading non-ASCII (e.g. emoji) and whitespace from a line.</summary>
+        private static string StripLeadingNonAscii(string s)
+        {
+            int i = 0;
+            while (i < s.Length && (s[i] > 127 || char.IsWhiteSpace(s[i]))) i++;
+            return s.Substring(i);
         }
         
         /// <summary>
@@ -829,7 +895,23 @@ namespace VibeUnity.Editor
     }
     
     #region Data Structures
-    
+
+    /// <summary>
+    /// Machine-readable result written to .vibe-unity/commands/results/ so an
+    /// external agent can poll a definitive outcome instead of scraping logs.
+    /// </summary>
+    [System.Serializable]
+    public class BatchResult
+    {
+        public int schemaVersion;
+        public string sourceFile;
+        public bool success;
+        public string status;       // "SUCCESS" | "FAILURE"
+        public string timestampUtc;
+        public string message;
+        public string[] errors;
+    }
+
     /// <summary>
     /// Root structure for batch command files
     /// </summary>

--- a/Editor/VibeUnityJSONProcessor.cs
+++ b/Editor/VibeUnityJSONProcessor.cs
@@ -64,6 +64,14 @@ namespace VibeUnity.Editor
                 logCapture.AppendLine($"✅ Batch file loaded: {batchFile.commands.Length} commands");
                 logCapture.AppendLine($"Description: {batchFile.description}");
                 logCapture.AppendLine();
+
+                // Detect editor-control-only batches (e.g. recompile) so we skip the
+                // scene save/export tail for them.
+                bool onlyControlCommands = true;
+                foreach (var c in batchFile.commands)
+                {
+                    if (!IsControlCommand(c.action)) { onlyControlCommands = false; break; }
+                }
                 
                 // Handle scene configuration if present (JsonUtility never returns null for
                 // object fields, so check name is non-empty to detect an actual scene block)
@@ -97,37 +105,44 @@ namespace VibeUnity.Editor
                     logCapture.AppendLine();
                 }
                 
-                // Save all scenes after batch execution
-                logCapture.AppendLine("Saving scenes and refreshing asset database...");
-                // Force save the active scene specifically
-                VibeUnityScenes.ForceSaveActiveScene();
-                // Also save any other open scenes
-                EditorSceneManager.SaveOpenScenes();
-                AssetDatabase.Refresh();
-                logCapture.AppendLine("✅ Scenes saved and asset database refreshed");
-                
-                // Generate scene state artifact after batch processing
-                logCapture.AppendLine("Generating scene state artifact...");
-                try
+                if (!onlyControlCommands)
                 {
-                    if (VibeUnitySceneExporter.ExportActiveSceneState())
+                    // Save all scenes after batch execution
+                    logCapture.AppendLine("Saving scenes and refreshing asset database...");
+                    // Force save the active scene specifically
+                    VibeUnityScenes.ForceSaveActiveScene();
+                    // Also save any other open scenes
+                    EditorSceneManager.SaveOpenScenes();
+                    AssetDatabase.Refresh();
+                    logCapture.AppendLine("✅ Scenes saved and asset database refreshed");
+
+                    // Generate scene state artifact after batch processing
+                    logCapture.AppendLine("Generating scene state artifact...");
+                    try
                     {
-                        logCapture.AppendLine("✅ Scene state artifact generated successfully");
-                        logCapture.AppendLine("   └─ State file saved alongside scene file");
-                        logCapture.AppendLine("   └─ Coverage analysis report generated");
+                        if (VibeUnitySceneExporter.ExportActiveSceneState())
+                        {
+                            logCapture.AppendLine("✅ Scene state artifact generated successfully");
+                            logCapture.AppendLine("   └─ State file saved alongside scene file");
+                            logCapture.AppendLine("   └─ Coverage analysis report generated");
+                        }
+                        else
+                        {
+                            logCapture.AppendLine("⚠️ Warning: Scene state artifact generation failed");
+                            logCapture.AppendLine("   └─ Check console for export error details");
+                        }
                     }
-                    else
+                    catch (System.Exception e)
                     {
-                        logCapture.AppendLine("⚠️ Warning: Scene state artifact generation failed");
-                        logCapture.AppendLine("   └─ Check console for export error details");
+                        logCapture.AppendLine($"⚠️ Warning: Exception during scene state export: {e.Message}");
+                        logCapture.AppendLine("   └─ Batch processing completed successfully despite export issue");
                     }
                 }
-                catch (System.Exception e)
+                else
                 {
-                    logCapture.AppendLine($"⚠️ Warning: Exception during scene state export: {e.Message}");
-                    logCapture.AppendLine("   └─ Batch processing completed successfully despite export issue");
+                    logCapture.AppendLine("Control-only batch (recompile/refresh): skipping scene save/export.");
                 }
-                
+
                 overallSuccess = true;
                 return true;
             }
@@ -346,9 +361,43 @@ namespace VibeUnity.Editor
                     return ExecuteAddComponentCommandWithLogging(command, logCapture);
                 case "add-gameobject":
                     return ExecuteAddGameObjectCommandWithLogging(command, logCapture);
+                case "recompile":
+                case "refresh":
+                    return ExecuteRecompileCommandWithLogging(command, logCapture);
                 default:
-                    logCapture.AppendLine($"❌ ERROR: Unknown batch command: {command.action}");
+                    logCapture.AppendLine($"ERROR: Unknown batch command: {command.action}");
                     return false;
+            }
+        }
+
+        /// <summary>
+        /// Whether an action only controls the editor (no scene mutation), so the
+        /// scene save/export tail can be skipped.
+        /// </summary>
+        private static bool IsControlCommand(string action)
+        {
+            string a = (action ?? "").ToLower();
+            return a == "recompile" || a == "refresh";
+        }
+
+        /// <summary>
+        /// Requests an asset refresh + script recompilation. This is the deterministic,
+        /// focus-free alternative to stealing the Unity window with AppActivate.
+        /// </summary>
+        private static bool ExecuteRecompileCommandWithLogging(BatchCommand command, StringBuilder logCapture)
+        {
+            try
+            {
+                logCapture.AppendLine("Executing recompile command...");
+                AssetDatabase.Refresh();
+                UnityEditor.Compilation.CompilationPipeline.RequestScriptCompilation();
+                logCapture.AppendLine("SUCCESS: requested AssetDatabase.Refresh + script compilation");
+                return true;
+            }
+            catch (System.Exception e)
+            {
+                logCapture.AppendLine($"FAIL: recompile request failed: {e.Message}");
+                return false;
             }
         }
         

--- a/Editor/VibeUnitySceneExporter.cs
+++ b/Editor/VibeUnitySceneExporter.cs
@@ -81,18 +81,30 @@ namespace VibeUnity.Editor
                     outputPath = scenePath;
                 }
                 
-                // Export the scene state manually as JSON
-                string jsonContent = ExportSceneToJsonManually(activeScene);
-                
-                // Write to file
+                // Build the FULL scene state (every component, transform, UI info,
+                // scene settings, asset refs and a coverage report) and serialize with
+                // JsonUtility so it round-trips with the importer (FromJson<SceneState>).
+                // This replaces the old hand-built JSON that silently dropped all
+                // non-script components and produced a schema the importer couldn't read.
+                SceneState state = ExportSceneToFullState(activeScene);
+                string jsonContent = JsonUtility.ToJson(state, true);
                 File.WriteAllText(outputPath, jsonContent);
-                
-                Debug.Log($"[VibeUnitySceneExporter] ✅ Scene state exported (manual JSON): {outputPath}");
-                Debug.Log($"[VibeUnitySceneExporter] File size: {new FileInfo(outputPath).Length} bytes");
-                
+
+                var summary = state.coverageReport != null ? state.coverageReport.summary : null;
+                if (summary != null)
+                {
+                    Debug.Log($"[VibeUnitySceneExporter] Scene state exported: {outputPath} " +
+                              $"({summary.totalGameObjects} objects, {summary.totalComponents} components, " +
+                              $"{summary.coveragePercentage:F0}% coverage, canRebuild={summary.canFullyRebuild})");
+                }
+                else
+                {
+                    Debug.Log($"[VibeUnitySceneExporter] Scene state exported: {outputPath}");
+                }
+
                 // Refresh asset database to show new file
                 AssetDatabase.Refresh();
-                
+
                 return true;
             }
             catch (Exception e)
@@ -104,7 +116,41 @@ namespace VibeUnity.Editor
         }
         
         /// <summary>
-        /// Exports scene directly to JSON string with manual building (ULTRA-MINIMALIST)
+        /// Builds a complete SceneState (all components, transforms, UI info, scene
+        /// settings, asset references and a coverage report) using the full export
+        /// helpers. This is the authoritative representation the importer consumes.
+        /// </summary>
+        private static SceneState ExportSceneToFullState(Scene scene)
+        {
+            var assetReferences = new HashSet<string>();
+            var coverageData = new CoverageAnalysisData();
+            var gameObjectsList = new List<GameObjectInfo>();
+
+            foreach (GameObject root in scene.GetRootGameObjects())
+            {
+                ExportGameObjectRecursive(root, "", gameObjectsList, assetReferences, coverageData);
+            }
+
+            var metadata = ExportSceneMetadata(scene);
+            metadata.totalGameObjects = gameObjectsList.Count;
+            metadata.totalComponents = coverageData.GetTotalComponents();
+
+            return new SceneState
+            {
+                version = "2.0",
+                exportTime = DateTime.Now,
+                metadata = metadata,
+                gameObjects = gameObjectsList.ToArray(),
+                settings = ExportSceneSettings(),
+                assetReferences = new List<string>(assetReferences).ToArray(),
+                coverageReport = GenerateCoverageReport(coverageData, gameObjectsList.Count)
+            };
+        }
+
+        /// <summary>
+        /// DEPRECATED and UNUSED: hand-built JSON that dropped non-script components
+        /// and did not match the importer schema. Retained only for reference; the
+        /// live path now uses ExportSceneToFullState. Do not call.
         /// </summary>
         private static string ExportSceneToJsonManually(Scene scene)
         {

--- a/Editor/VibeUnitySettings.cs
+++ b/Editor/VibeUnitySettings.cs
@@ -40,22 +40,24 @@ namespace VibeUnity.Editor
         /// <summary>
         /// Save settings to file
         /// </summary>
-        public static void SaveSettings(VibeUnitySettingsData settings)
+        public static bool SaveSettings(VibeUnitySettingsData settings)
         {
             try
             {
                 string json = JsonUtility.ToJson(settings, true);
                 File.WriteAllText(settingsPath, json);
                 cachedSettings = settings;
-                
+
                 Debug.Log($"[VibeUnity] Settings saved to: {settingsPath}");
-                
+
                 // Update menu items with new shortcuts
                 VibeUnityCompilationController.UpdateShortcuts(settings.shortcuts);
+                return true;
             }
             catch (Exception e)
             {
                 Debug.LogError($"[VibeUnity] Failed to save settings: {e.Message}");
+                return false;
             }
         }
         
@@ -70,7 +72,17 @@ namespace VibeUnity.Editor
                 {
                     string json = File.ReadAllText(settingsPath);
                     cachedSettings = JsonUtility.FromJson<VibeUnitySettingsData>(json);
-                    
+
+                    // Heal a corrupt/empty file rather than NRE'ing on every load and
+                    // leaving the bad file in place.
+                    if (cachedSettings == null)
+                    {
+                        Debug.LogWarning("[VibeUnity] Settings file was unreadable; regenerating defaults.");
+                        cachedSettings = CreateDefaultSettings();
+                        SaveSettings(cachedSettings);
+                        return;
+                    }
+
                     // Validate and fill in any missing shortcuts with defaults
                     if (cachedSettings.shortcuts == null)
                     {

--- a/Editor/VibeUnitySettingsWindow.cs
+++ b/Editor/VibeUnitySettingsWindow.cs
@@ -107,8 +107,11 @@ namespace VibeUnity.Editor
             {
                 if (GUILayout.Button("Save Settings"))
                 {
-                    VibeUnitySettings.SaveSettings(settings);
-                    ShowNotification(new GUIContent("Settings saved!"));
+                    if (VibeUnitySettings.SaveSettings(settings))
+                        ShowNotification(new GUIContent("Settings saved!"));
+                    else
+                        EditorUtility.DisplayDialog("Vibe Unity",
+                            "Failed to save settings. See the Console for details.", "OK");
                 }
                 
                 if (GUILayout.Button("Reset to Defaults"))

--- a/Editor/VibeUnitySetup.cs
+++ b/Editor/VibeUnitySetup.cs
@@ -2,6 +2,7 @@
 using UnityEditor;
 using UnityEngine;
 using System.IO;
+using System.Collections.Generic;
 
 namespace VibeUnity.Editor
 {
@@ -11,119 +12,168 @@ namespace VibeUnity.Editor
     [InitializeOnLoad]
     public static class VibeUnitySetup
     {
-        private const string SETUP_COMPLETE_KEY = "VibeUnity_SetupComplete";
-        
+        // Project-scoped key. EditorPrefs is machine-global, so an unqualified key
+        // would let the first project that runs setup mark EVERY other project on
+        // the machine as "already set up", silently skipping their script install.
+        private static string SetupCompleteKey => $"VibeUnity_SetupComplete_{ProjectId()}";
+
         static VibeUnitySetup()
         {
             // Only run setup once per project
-            if (!EditorPrefs.GetBool(SETUP_COMPLETE_KEY, false))
+            if (!EditorPrefs.GetBool(SetupCompleteKey, false))
             {
                 EditorApplication.delayCall += RunSetup;
             }
         }
-        
+
         private static void RunSetup()
         {
             Debug.Log("[Vibe Unity] Setting up CLI tools...");
-            
-            // Copy bash scripts to project root for WSL users
-            CopyBashScriptsToProjectRoot();
-            
-            // Mark setup as complete
-            EditorPrefs.SetBool(SETUP_COMPLETE_KEY, true);
-            
-            // Show welcome message
-            ShowWelcomeDialog();
+
+            var report = new List<string>();
+            bool essentialInstalled = CopyBashScriptsToProjectRoot(report);
+
+            // Only remember success when the essential script actually landed, so a
+            // failed/partial setup is retried on the next reload rather than skipped
+            // forever (previously setup was marked complete unconditionally).
+            if (essentialInstalled)
+            {
+                EditorPrefs.SetBool(SetupCompleteKey, true);
+            }
+
+            ShowWelcomeDialog(essentialInstalled, report);
         }
-        
-        private static void CopyBashScriptsToProjectRoot()
+
+        /// <returns>true if the essential claude-compile-check.sh was installed.</returns>
+        private static bool CopyBashScriptsToProjectRoot(List<string> report)
         {
+            bool essentialInstalled = false;
             try
             {
                 string packagePath = GetPackagePath();
-                if (string.IsNullOrEmpty(packagePath)) return;
-                
+                if (string.IsNullOrEmpty(packagePath))
+                {
+                    report.Add("FAILED: could not locate the Vibe Unity package path");
+                    Debug.LogWarning("[Vibe Unity] Could not locate package path; no scripts copied.");
+                    return false;
+                }
+
                 string scriptsPath = Path.Combine(packagePath, "Scripts");
+                string runtimePath = Path.Combine(packagePath, "Runtime");
                 string projectRoot = Directory.GetParent(Application.dataPath).FullName;
-                
-                // Copy claude-compile-check.sh script with LF line endings preserved
+
+                // 1) claude-compile-check.sh lives in Scripts/ -> project root (ESSENTIAL)
                 string sourceCompileCheck = Path.Combine(scriptsPath, "claude-compile-check.sh");
                 string targetCompileCheck = Path.Combine(projectRoot, "claude-compile-check.sh");
-                
                 if (File.Exists(sourceCompileCheck))
                 {
-                    // Always overwrite the compile check script to ensure latest version
-                    // Read with preserved line endings and write to preserve LF
-                    string content = File.ReadAllText(sourceCompileCheck);
-                    // Ensure Unix line endings (LF only)
-                    content = content.Replace("\r\n", "\n").Replace("\r", "\n");
-                    File.WriteAllText(targetCompileCheck, content);
-                    
-                    // Make executable on Unix systems
-                    if (System.Environment.OSVersion.Platform == System.PlatformID.Unix)
-                    {
-                        System.Diagnostics.Process.Start("chmod", $"+x \"{targetCompileCheck}\"");
-                    }
-                    
-                    Debug.Log($"[Vibe Unity] Updated compilation check script to latest version: {targetCompileCheck}");
-                    
-                    // Add to .gitignore to prevent line ending issues
+                    WriteWithUnixEndings(sourceCompileCheck, targetCompileCheck);
+                    MakeExecutable(targetCompileCheck);
                     AddToGitIgnore(projectRoot, "claude-compile-check.sh");
+                    essentialInstalled = true;
+                    report.Add("OK: claude-compile-check.sh");
+                    Debug.Log($"[Vibe Unity] Installed compile-check script: {targetCompileCheck}");
                 }
-                
-                // Copy vibe-unity script
-                string sourceScript = Path.Combine(scriptsPath, "vibe-unity");
+                else
+                {
+                    report.Add($"MISSING SOURCE: {sourceCompileCheck}");
+                    Debug.LogWarning($"[Vibe Unity] Essential source script not found: {sourceCompileCheck}");
+                }
+
+                // 2) vibe-unity CLI lives in Runtime/ (NOT Scripts/) -> project root
+                string sourceScript = Path.Combine(runtimePath, "vibe-unity");
                 string targetScript = Path.Combine(projectRoot, "vibe-unity");
-                
                 if (File.Exists(sourceScript))
                 {
-                    File.Copy(sourceScript, targetScript, true);
-                    Debug.Log($"[Vibe Unity] Copied CLI script to: {targetScript}");
+                    WriteWithUnixEndings(sourceScript, targetScript);
+                    MakeExecutable(targetScript);
+                    report.Add("OK: vibe-unity");
+                    Debug.Log($"[Vibe Unity] Installed CLI script: {targetScript}");
                 }
-                
-                // Copy install script
-                string sourceInstaller = Path.Combine(scriptsPath, "install-vibe-unity");
-                string targetInstaller = Path.Combine(projectRoot, "Scripts", "install-vibe-unity");
-                
+                else
+                {
+                    report.Add($"SKIPPED: vibe-unity not found at {sourceScript}");
+                }
+
+                // 3) install-vibe-unity lives in Runtime/ -> project Scripts/
+                string sourceInstaller = Path.Combine(runtimePath, "install-vibe-unity");
                 if (File.Exists(sourceInstaller))
                 {
-                    Directory.CreateDirectory(Path.Combine(projectRoot, "Scripts"));
-                    File.Copy(sourceInstaller, targetInstaller, true);
-                    Debug.Log($"[Vibe Unity] Copied installer to: {targetInstaller}");
+                    string targetScriptsDir = Path.Combine(projectRoot, "Scripts");
+                    Directory.CreateDirectory(targetScriptsDir);
+                    WriteWithUnixEndings(sourceInstaller, Path.Combine(targetScriptsDir, "install-vibe-unity"));
+                    report.Add("OK: install-vibe-unity");
+                }
+                else
+                {
+                    report.Add($"SKIPPED: install-vibe-unity not found at {sourceInstaller}");
+                }
+
+                return essentialInstalled;
+            }
+            catch (System.Exception e)
+            {
+                report.Add($"ERROR: {e.Message}");
+                Debug.LogWarning($"[Vibe Unity] Could not copy bash scripts: {e.Message}");
+                return essentialInstalled;
+            }
+        }
+
+        private static void WriteWithUnixEndings(string sourcePath, string targetPath)
+        {
+            string content = File.ReadAllText(sourcePath).Replace("\r\n", "\n").Replace("\r", "\n");
+            File.WriteAllText(targetPath, content);
+        }
+
+        private static void MakeExecutable(string path)
+        {
+            // chmod only matters on Unix-like editors (Linux/macOS). On Windows the
+            // bit is irrelevant and WSL/git-bash run the file regardless.
+            if (System.Environment.OSVersion.Platform != System.PlatformID.Unix) return;
+            try
+            {
+                var psi = new System.Diagnostics.ProcessStartInfo("chmod", $"+x \"{path}\"")
+                {
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+                var proc = System.Diagnostics.Process.Start(psi);
+                if (proc != null)
+                {
+                    proc.WaitForExit(5000);
+                    if (proc.ExitCode != 0)
+                        Debug.LogWarning($"[Vibe Unity] chmod +x returned {proc.ExitCode} for {path}");
                 }
             }
             catch (System.Exception e)
             {
-                Debug.LogWarning($"[Vibe Unity] Could not copy bash scripts: {e.Message}");
+                Debug.LogWarning($"[Vibe Unity] chmod failed for {path}: {e.Message}");
             }
         }
-        
+
         public static void AddToGitIgnore(string projectRoot, string fileName)
         {
             try
             {
                 string gitIgnorePath = Path.Combine(projectRoot, ".gitignore");
-                string entryToAdd = fileName;
-                
-                // Check if .gitignore exists
                 if (File.Exists(gitIgnorePath))
                 {
-                    string existingContent = File.ReadAllText(gitIgnorePath);
-                    
-                    // Check if the entry already exists
-                    if (!existingContent.Contains(entryToAdd))
+                    // Match a full trimmed line, not a substring, so a comment or a
+                    // longer path containing the name doesn't cause a false "present".
+                    bool present = false;
+                    foreach (string line in File.ReadAllLines(gitIgnorePath))
                     {
-                        // Add the entry with a comment
-                        string newEntry = $"\n# Vibe Unity - auto-generated script with Unix line endings\n{entryToAdd}\n";
-                        File.AppendAllText(gitIgnorePath, newEntry);
-                        Debug.Log($"[Vibe Unity] Added {fileName} to .gitignore to preserve line endings");
+                        if (line.Trim() == fileName) { present = true; break; }
+                    }
+                    if (!present)
+                    {
+                        File.AppendAllText(gitIgnorePath, $"\n# Vibe Unity - auto-generated script with Unix line endings\n{fileName}\n");
+                        Debug.Log($"[Vibe Unity] Added {fileName} to .gitignore");
                     }
                 }
                 else
                 {
-                    // Create .gitignore with the entry
-                    string content = $"# Vibe Unity - auto-generated script with Unix line endings\n{entryToAdd}\n";
-                    File.WriteAllText(gitIgnorePath, content);
+                    File.WriteAllText(gitIgnorePath, $"# Vibe Unity - auto-generated script with Unix line endings\n{fileName}\n");
                     Debug.Log($"[Vibe Unity] Created .gitignore and added {fileName}");
                 }
             }
@@ -132,51 +182,64 @@ namespace VibeUnity.Editor
                 Debug.LogWarning($"[Vibe Unity] Could not update .gitignore: {e.Message}");
             }
         }
-        
+
         private static string GetPackagePath()
         {
-            // Try to find the package in various locations
-            string[] searchPaths = {
-                Path.Combine(Application.dataPath, "..", "Packages", "com.vibe.unity"),
-                Path.Combine(Application.dataPath, "..", "Library", "PackageCache", "com.vibe.unity@1.0.0"),
-                Path.Combine(Application.dataPath, "VibeUnity") // Local package
-            };
-            
-            foreach (string path in searchPaths)
-            {
-                if (Directory.Exists(path))
-                {
-                    return path;
-                }
-            }
-            
-            return null;
+            // Resolve the real installed location regardless of install method
+            // (git URL, local file:, or PackageCache) instead of guessing hardcoded,
+            // version-pinned, and wrongly-named paths.
+            var pkg = UnityEditor.PackageManager.PackageInfo.FindForAssembly(typeof(VibeUnitySetup).Assembly);
+            if (pkg != null && !string.IsNullOrEmpty(pkg.resolvedPath) && Directory.Exists(pkg.resolvedPath))
+                return pkg.resolvedPath;
+
+            // Fallback for an embedded copy under Assets/.
+            string local = Path.Combine(Application.dataPath, "VibeUnity");
+            return Directory.Exists(local) ? local : null;
         }
-        
-        private static void ShowWelcomeDialog()
+
+        private static string ProjectId()
+        {
+            // Deterministic short id from the project path (GetHashCode is not stable
+            // across runs and must not be used for a persisted key).
+            using (var md5 = System.Security.Cryptography.MD5.Create())
+            {
+                byte[] hash = md5.ComputeHash(System.Text.Encoding.UTF8.GetBytes(Application.dataPath));
+                return System.BitConverter.ToString(hash, 0, 4).Replace("-", "");
+            }
+        }
+
+        private static void ShowWelcomeDialog(bool essentialInstalled, List<string> report)
         {
             EditorApplication.delayCall += () =>
             {
-                bool showDialog = EditorUtility.DisplayDialog(
-                    "Vibe Unity",
-                    "Unity Vibe CLI has been installed!\n\n" +
-                    "You can now:\n" +
-                    "• Use the C# API: CLI.CreateScene(), CLI.AddCanvas()\n" +
-                    "• Access Tools > Vibe Unity menu\n" +
-                    "• WSL users: Run ./vibe-unity from project root\n\n" +
-                    "Would you like to see the documentation?",
-                    "Open Documentation",
-                    "Close"
-                );
-                
-                if (showDialog)
+                string summary = string.Join("\n", report.ToArray());
+                if (essentialInstalled)
                 {
-                    Application.OpenURL("https://github.com/RICoder72/vibe-unity#readme");
+                    bool open = EditorUtility.DisplayDialog(
+                        "Vibe Unity",
+                        "Vibe Unity CLI tools installed.\n\n" +
+                        summary + "\n\n" +
+                        "Usage:\n" +
+                        "- Drop JSON commands in .vibe-unity/commands/\n" +
+                        "- Run ./claude-compile-check.sh to validate compilation\n" +
+                        "- Use the Tools > Vibe Unity menu\n\n" +
+                        "Open the documentation?",
+                        "Open Documentation",
+                        "Close");
+                    if (open)
+                        Application.OpenURL("https://github.com/RICoder72/vibe-unity#readme");
+                }
+                else
+                {
+                    EditorUtility.DisplayDialog(
+                        "Vibe Unity - Setup Incomplete",
+                        "Vibe Unity could not install its essential CLI script.\n\n" +
+                        summary + "\n\n" +
+                        "Setup will retry on the next editor reload. See the Console for details.",
+                        "OK");
                 }
             };
         }
-        
-        // Reset setup functionality removed - menu consolidated in VibeUnityMenu.cs
     }
 }
 #endif

--- a/Editor/VibeUnitySystem.cs
+++ b/Editor/VibeUnitySystem.cs
@@ -54,7 +54,10 @@ namespace VibeUnity.Editor
             
             // Set up scene state auto-generation hooks
             InitializeSceneStateHooks();
-            
+
+            // Capture Unity console output for the external agent to read
+            InitializeConsoleCapture();
+
             // Also check for existing files on startup
             CheckForCommandFiles();
         }
@@ -89,6 +92,101 @@ namespace VibeUnity.Editor
         }
         
         
+        #endregion
+
+        #region Console Log Capture
+
+        // Rolling capture of Unity console output to .vibe-unity/logs/console.json so
+        // the external agent can read runtime logs/warnings/errors it otherwise cannot
+        // see. The callback fires on background threads, so we buffer under a lock and
+        // flush on the editor tick (throttled). No Unity API is touched in the callback.
+        private const int CONSOLE_CAPACITY = 500;
+        private static readonly List<VibeConsoleEntry> consoleBuffer = new List<VibeConsoleEntry>();
+        private static readonly object consoleLock = new object();
+        private static bool consoleDirty = false;
+        private static double lastConsoleFlush = 0;
+        private static string ConsoleLogPath =>
+            Path.Combine(Application.dataPath, "..", ".vibe-unity", "logs", "console.json");
+
+        private static void InitializeConsoleCapture()
+        {
+            Application.logMessageReceivedThreaded -= OnConsoleMessage;
+            Application.logMessageReceivedThreaded += OnConsoleMessage;
+            EditorApplication.update -= FlushConsoleIfNeeded;
+            EditorApplication.update += FlushConsoleIfNeeded;
+        }
+
+        private static void OnConsoleMessage(string message, string stackTrace, LogType type)
+        {
+            // DateTime.UtcNow is thread-safe (.NET, not a Unity API), so it is safe here.
+            lock (consoleLock)
+            {
+                consoleBuffer.Add(new VibeConsoleEntry
+                {
+                    type = type.ToString(),
+                    message = message,
+                    stackTrace = stackTrace,
+                    timeUtc = System.DateTime.UtcNow.ToString("o")
+                });
+                if (consoleBuffer.Count > CONSOLE_CAPACITY)
+                    consoleBuffer.RemoveRange(0, consoleBuffer.Count - CONSOLE_CAPACITY);
+                consoleDirty = true;
+            }
+        }
+
+        private static void FlushConsoleIfNeeded()
+        {
+            if (!consoleDirty) return;
+            double now = EditorApplication.timeSinceStartup;
+            if (now - lastConsoleFlush < 1.0) return; // throttle to ~1 Hz
+            lastConsoleFlush = now;
+
+            VibeConsoleEntry[] snapshot;
+            lock (consoleLock)
+            {
+                snapshot = consoleBuffer.ToArray();
+                consoleDirty = false;
+            }
+
+            try
+            {
+                var log = new VibeConsoleLog
+                {
+                    updatedUtc = System.DateTime.UtcNow.ToString("o"),
+                    count = snapshot.Length,
+                    entries = snapshot
+                };
+                Directory.CreateDirectory(Path.GetDirectoryName(ConsoleLogPath));
+                File.WriteAllText(ConsoleLogPath, JsonUtility.ToJson(log, true));
+            }
+            catch (System.Exception e)
+            {
+                // Do not re-log at error level here or we risk a capture feedback loop.
+                Debug.LogWarning($"[VibeUnity] Failed to write console capture: {e.Message}");
+            }
+        }
+
+        [System.Serializable]
+        public class VibeConsoleEntry
+        {
+            public string type;       // Log | Warning | Error | Assert | Exception
+            public string message;
+            public string stackTrace;
+            public string timeUtc;
+        }
+
+        [System.Serializable]
+        public class VibeConsoleLog
+        {
+            public string updatedUtc;
+            public int count;
+            public VibeConsoleEntry[] entries;
+        }
+
+        #endregion
+
+        #region File Watcher System (cont.)
+
         /// <summary>
         /// Checks for existing command files and processes them
         /// </summary>
@@ -131,21 +229,30 @@ namespace VibeUnity.Editor
                     
                     // Use the JSON processor to handle the file
                     bool success = VibeUnityJSONProcessor.ProcessBatchFileWithLogging(filePath);
-                    
-                    // Move processed file to processed directory
-                    string processedDir = Path.Combine(COMMAND_QUEUE_DIR, "processed");
-                    if (!Directory.Exists(processedDir))
+
+                    // Route to processed/ or failed/ based on the actual outcome, so a
+                    // failed command is no longer silently archived as if it succeeded.
+                    string targetSubdir = success ? "processed" : "failed";
+                    string targetDir = Path.Combine(COMMAND_QUEUE_DIR, targetSubdir);
+                    if (!Directory.Exists(targetDir))
                     {
-                        Directory.CreateDirectory(processedDir);
+                        Directory.CreateDirectory(targetDir);
                     }
-                    
+
                     string fileName = Path.GetFileName(filePath);
                     string timestamp = System.DateTime.Now.ToString("yyyyMMdd-HHmmss");
-                    string fileNameWithoutExt = Path.GetFileNameWithoutExtension(fileName);
-                    string processedJsonPath = Path.Combine(processedDir, $"{timestamp}-{fileName}");
-                    
-                    File.Move(filePath, processedJsonPath);
-                    Debug.Log($"[VibeUnity] Moved processed file to: {processedJsonPath}");
+                    string targetJsonPath = Path.Combine(targetDir, $"{timestamp}-{fileName}");
+
+                    File.Move(filePath, targetJsonPath);
+                    if (success)
+                    {
+                        Debug.Log($"[VibeUnity] Processed (SUCCESS): {targetJsonPath}");
+                    }
+                    else
+                    {
+                        Debug.LogError($"[VibeUnity] Command FAILED; moved to failed/: {fileName}. " +
+                                       "See .vibe-unity/commands/results/latest.result.json");
+                    }
                 }
                 catch (System.Exception e)
                 {
@@ -205,10 +312,14 @@ namespace VibeUnity.Editor
             
             // Remove the main thread dispatcher
             EditorApplication.update -= ProcessMainThreadQueue;
-            
+
             // Cleanup compilation tracker
             EditorApplication.update -= MonitorCompilationState;
             CleanupCompilationTracker();
+
+            // Cleanup console capture
+            Application.logMessageReceivedThreaded -= OnConsoleMessage;
+            EditorApplication.update -= FlushConsoleIfNeeded;
         }
         
         #endregion

--- a/Editor/VibeUnityUI.cs
+++ b/Editor/VibeUnityUI.cs
@@ -407,7 +407,19 @@ namespace VibeUnity.Editor
                 // Assign references to ScrollRect
                 scrollRect.viewport = viewportRect;
                 scrollRect.content = contentRect;
-                
+
+                // Create and wire actual Scrollbar objects so the visibility modes
+                // (e.g. AutoHideAndExpandViewport) function. Previously the visibility
+                // was set but no scrollbars existed and the references stayed null.
+                if (horizontal)
+                {
+                    scrollRect.horizontalScrollbar = CreateScrollbar(scrollViewGO, false);
+                }
+                if (vertical)
+                {
+                    scrollRect.verticalScrollbar = CreateScrollbar(scrollViewGO, true);
+                }
+
                 // Log detailed success information
                 Debug.Log($"[VibeUnity] ✅ SUCCESS: Created scroll view '{scrollViewName}'");
                 Debug.Log($"[VibeUnity]    └─ Parent: {parent.name} (Type: {parent.GetComponent<Canvas>()?.GetType().Name ?? parent.GetType().Name})");
@@ -435,7 +447,59 @@ namespace VibeUnity.Editor
         #endregion
         
         #region Helper Methods
-        
+
+        /// <summary>
+        /// Creates a functional Scrollbar (background + sliding area + handle) parented
+        /// to the scroll view, matching the structure Unity's UI menu produces.
+        /// </summary>
+        private static Scrollbar CreateScrollbar(GameObject scrollViewGO, bool vertical)
+        {
+            string name = vertical ? "Scrollbar Vertical" : "Scrollbar Horizontal";
+            GameObject sbGO = new GameObject(name);
+            sbGO.transform.SetParent(scrollViewGO.transform, false);
+
+            RectTransform sbRect = sbGO.AddComponent<RectTransform>();
+            if (vertical)
+            {
+                sbRect.anchorMin = new Vector2(1, 0);
+                sbRect.anchorMax = new Vector2(1, 1);
+                sbRect.pivot = new Vector2(1, 1);
+                sbRect.sizeDelta = new Vector2(20, 0);
+            }
+            else
+            {
+                sbRect.anchorMin = new Vector2(0, 0);
+                sbRect.anchorMax = new Vector2(1, 0);
+                sbRect.pivot = new Vector2(0, 0);
+                sbRect.sizeDelta = new Vector2(0, 20);
+            }
+
+            Image sbImage = sbGO.AddComponent<Image>();
+            sbImage.color = new Color(0.86f, 0.86f, 0.86f, 1f);
+
+            Scrollbar scrollbar = sbGO.AddComponent<Scrollbar>();
+            scrollbar.direction = vertical ? Scrollbar.Direction.BottomToTop : Scrollbar.Direction.LeftToRight;
+
+            GameObject slidingArea = new GameObject("Sliding Area");
+            slidingArea.transform.SetParent(sbGO.transform, false);
+            RectTransform saRect = slidingArea.AddComponent<RectTransform>();
+            saRect.anchorMin = Vector2.zero;
+            saRect.anchorMax = Vector2.one;
+            saRect.offsetMin = new Vector2(10, 10);
+            saRect.offsetMax = new Vector2(-10, -10);
+
+            GameObject handle = new GameObject("Handle");
+            handle.transform.SetParent(slidingArea.transform, false);
+            RectTransform handleRect = handle.AddComponent<RectTransform>();
+            handleRect.sizeDelta = new Vector2(20, 20);
+            Image handleImage = handle.AddComponent<Image>();
+            handleImage.color = new Color(0.66f, 0.66f, 0.66f, 1f);
+
+            scrollbar.handleRect = handleRect;
+            scrollbar.targetGraphic = handleImage;
+            return scrollbar;
+        }
+
         /// <summary>
         /// Parses render mode from string
         /// </summary>

--- a/Runtime/install-vibe-unity
+++ b/Runtime/install-vibe-unity
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-# Unity Vibe CLI - Installation Script for WSL
-# This script copies vibe-unity to the project root for easy access
+# Unity Vibe CLI - Installation Script (WSL + git-bash)
+# Copies vibe-unity to the project root for easy access.
+
+set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -15,58 +17,63 @@ echo ""
 
 # Check if source vibe-unity script exists
 if [ ! -f "$SOURCE_VIBE_UNITY" ]; then
-    echo "❌ Error: vibe-unity script not found at $SOURCE_VIBE_UNITY"
+    echo "ERROR: vibe-unity script not found at $SOURCE_VIBE_UNITY" >&2
     exit 1
 fi
 
 # Copy vibe-unity to project root
 if cp "$SOURCE_VIBE_UNITY" "$TARGET_VIBE_UNITY"; then
-    echo "✅ Copied vibe-unity to project root"
+    echo "[OK] Copied vibe-unity to project root"
 else
-    echo "❌ Failed to copy vibe-unity to project root"
+    echo "ERROR: Failed to copy vibe-unity to project root" >&2
     exit 1
 fi
 
-# Make sure the script is executable
-chmod +x "$TARGET_VIBE_UNITY"
-echo "✅ Made vibe-unity executable"
+# Make the script executable (non-fatal on filesystems that ignore the mode bit)
+chmod +x "$TARGET_VIBE_UNITY" 2>/dev/null \
+    || echo "WARNING: could not mark vibe-unity executable (chmod failed)" >&2
 
-# Test Unity installation
+# Detect the newest installed Unity across WSL (/mnt/c) and git-bash (/c) mounts.
+find_unity_exe() {
+    local base candidates=()
+    for base in \
+        "/mnt/c/Program Files/Unity/Hub/Editor" \
+        "/c/Program Files/Unity/Hub/Editor"; do
+        [[ -d "$base" ]] || continue
+        while IFS= read -r exe; do
+            [[ -n "$exe" ]] && candidates+=("$exe")
+        done < <(find "$base" -maxdepth 2 -name Unity.exe 2>/dev/null)
+    done
+    [[ ${#candidates[@]} -gt 0 ]] && printf '%s\n' "${candidates[@]}" | sort -V | tail -1
+}
+
 echo ""
-echo "🔍 Checking Unity installation..."
-
-if command -v /mnt/c/Program\ Files/Unity/Hub/Editor/*/Editor/Unity.exe >/dev/null 2>&1; then
-    UNITY_PATH=$(find /mnt/c/Program\ Files/Unity/Hub/Editor/*/Editor/Unity.exe | head -1)
-    echo "✅ Unity found at: $UNITY_PATH"
+echo "Checking Unity installation..."
+UNITY_PATH="$(find_unity_exe)"
+if [ -n "$UNITY_PATH" ]; then
+    echo "[OK] Unity found at: $UNITY_PATH"
 else
-    echo "❌ Unity Editor not found in standard locations"
-    echo "   Please ensure Unity is installed via Unity Hub"
-    echo "   Expected location: /mnt/c/Program Files/Unity/Hub/Editor/*/Editor/Unity.exe"
+    echo "[WARN] Unity Editor not found in standard Unity Hub locations"
+    echo "       Install Unity via Unity Hub if you need batch-mode commands."
 fi
 
 echo ""
-echo "🎉 Installation complete!"
-echo ""
-echo "Usage:"
-echo "From your Unity project root directory, run:"
+echo "Usage (run from your Unity project root directory):"
 echo "  ./vibe-unity --help"
 echo "  ./vibe-unity create-scene MyScene Assets/Scenes"
 echo "  ./vibe-unity add-canvas MainCanvas"
 echo ""
-echo "Important notes:"
-echo "• Unity Editor must be closed before running CLI commands"
-echo "• Run commands from your Unity project root directory"
-echo ""
 
-# Test if we can run vibe-unity
-echo "🧪 Testing installation..."
-if "$TARGET_VIBE_UNITY" --version >/dev/null 2>&1; then
-    echo "✅ vibe-unity is working correctly"
+# Self-test: confirm the installed script is runnable and reports a version.
+# (This validates the install, not the Unity connection.)
+echo "Testing installation..."
+if VERSION_OUT="$("$TARGET_VIBE_UNITY" --version 2>/dev/null)" && [ -n "$VERSION_OUT" ]; then
+    echo "[OK] vibe-unity is runnable: $VERSION_OUT"
 else
-    echo "❌ vibe-unity test failed - check Unity installation"
+    echo "[FAIL] vibe-unity did not run correctly" >&2
 fi
 
 echo ""
 echo "Installation summary:"
-echo "• Script location: $TARGET_VIBE_UNITY"
-echo "• Unity detected: $([ -n "$UNITY_PATH" ] && echo "Yes" || echo "No")"
+echo "  Script location: $TARGET_VIBE_UNITY"
+echo "  Unity detected:  $([ -n "$UNITY_PATH" ] && echo "Yes" || echo "No")"

--- a/Runtime/vibe-unity
+++ b/Runtime/vibe-unity
@@ -15,24 +15,58 @@
 
 VERSION="1.0.0"
 
-# Check if Unity executable exists
-UNITY_PATH=""
-if command -v /mnt/c/Program\ Files/Unity/Hub/Editor/*/Editor/Unity.exe >/dev/null 2>&1; then
-    UNITY_PATH=$(find /mnt/c/Program\ Files/Unity/Hub/Editor/*/Editor/Unity.exe | head -1)
-elif command -v unity >/dev/null 2>&1; then
+# Locate the newest installed Unity.exe across WSL (/mnt/c) and git-bash (/c) mounts.
+find_unity_exe() {
+    local base candidates=()
+    for base in \
+        "/mnt/c/Program Files/Unity/Hub/Editor" \
+        "/c/Program Files/Unity/Hub/Editor" \
+        "/mnt/c/Program Files/Unity/Editor" \
+        "/c/Program Files/Unity/Editor"; do
+        [[ -d "$base" ]] || continue
+        while IFS= read -r exe; do
+            [[ -n "$exe" ]] && candidates+=("$exe")
+        done < <(find "$base" -maxdepth 2 -name Unity.exe 2>/dev/null)
+    done
+    if [[ ${#candidates[@]} -gt 0 ]]; then
+        # sort -V => highest version last
+        printf '%s\n' "${candidates[@]}" | sort -V | tail -1
+    fi
+}
+
+# Unity executable is only required for batch mode (Unity closed). When Unity is
+# running we use the file-watcher path, so a missing exe is non-fatal here.
+UNITY_PATH="$(find_unity_exe)"
+if [[ -z "$UNITY_PATH" ]] && command -v unity >/dev/null 2>&1; then
     UNITY_PATH="unity"
-else
-    echo "Error: Unity Editor not found. Please ensure Unity is installed and accessible."
-    exit 1
 fi
 
-# Convert WSL path to Windows path for Unity
+# Convert the current dir to a Windows path Unity understands (WSL + git-bash).
 get_project_path() {
-    if [[ $(pwd) == /mnt/c/* ]]; then
-        echo $(pwd | sed 's|/mnt/c|C:|')
-    else
-        echo $(pwd)
+    local p win=""
+    p="$(pwd)"
+    if grep -qiE 'microsoft|wsl' /proc/version 2>/dev/null && command -v wslpath >/dev/null 2>&1; then
+        win="$(wslpath -w "$p" 2>/dev/null)"
+    elif command -v cygpath >/dev/null 2>&1; then
+        win="$(cygpath -w "$p" 2>/dev/null)"
     fi
+    if [[ -n "$win" ]]; then
+        echo "$win"
+    else
+        # Best-effort fallback for /mnt/<drive>/ and /<drive>/ style paths.
+        echo "$p" | sed -E -e 's|^/mnt/([a-zA-Z])/|\1:/|' -e 's|^/([a-zA-Z])/|\1:/|'
+    fi
+}
+
+# Block until a file appears (used to confirm async command results). Args: path, timeout-seconds.
+wait_for_file() {
+    local target="$1" timeout="${2:-20}" waited=0
+    while [[ $waited -lt $timeout ]]; do
+        [[ -f "$target" ]] && return 0
+        sleep 1
+        waited=$((waited + 1))
+    done
+    return 1
 }
 
 # Create JSON batch file for create-scene command and queue it via file watcher
@@ -42,10 +76,10 @@ create_scene_batch_file() {
     local scene_type="${3:-DefaultGameObjects}"
     local add_to_build="${4:-false}"
     
-    # Create .vibe-commands directory if it doesn't exist
-    local command_dir=".vibe-commands"
+    # Drop the command where the Unity file watcher actually looks.
+    local command_dir=".vibe-unity/commands"
     mkdir -p "$command_dir"
-    
+
     # Generate unique filename with timestamp
     local timestamp=$(date +%Y%m%d-%H%M%S-%N)
     local batch_file="$command_dir/create-scene-$timestamp.json"
@@ -67,10 +101,9 @@ create_scene_batch_file() {
 }
 EOF
     
-    echo "📁 Generated batch file: $(basename "$batch_file")"
-    echo "🔍 Unity will automatically process this file via file watcher"
-    echo "💡 Check Unity Console for execution status"
-    
+    echo "Submitted command file: $(basename "$batch_file")" >&2
+    echo "Awaiting Unity file watcher to process it..." >&2
+
     return 0
 }
 
@@ -83,10 +116,10 @@ create_canvas_batch_file() {
     local height="${5:-1080}"
     local scale_mode="${6:-ScaleWithScreenSize}"
     
-    # Create .vibe-commands directory if it doesn't exist
-    local command_dir=".vibe-commands"
+    # Drop the command where the Unity file watcher actually looks.
+    local command_dir=".vibe-unity/commands"
     mkdir -p "$command_dir"
-    
+
     # Generate unique filename with timestamp
     local timestamp=$(date +%Y%m%d-%H%M%S-%N)
     local batch_file="$command_dir/add-canvas-$timestamp.json"
@@ -110,10 +143,9 @@ create_canvas_batch_file() {
 }
 EOF
     
-    echo "📁 Generated batch file: $(basename "$batch_file")"
-    echo "🔍 Unity will automatically process this file via file watcher"
-    echo "💡 Check Unity Console for execution status"
-    
+    echo "Submitted command file: $(basename "$batch_file")" >&2
+    echo "Awaiting Unity file watcher to process it..." >&2
+
     return 0
 }
 
@@ -282,7 +314,7 @@ execute_unity_command() {
             *)
                 echo "💡 Command '$method' not yet supported for automatic file watcher conversion"
                 echo "   Supported commands: create-scene, add-canvas"
-                echo "   Place JSON batch files in .vibe-commands/ directory manually"
+                echo "   Place JSON batch files in .vibe-unity/commands/ directory manually"
                 echo "   Unity will automatically process them via the file watcher"
                 echo ""
                 echo "🚫 Skipping command execution to avoid Unity instance conflicts"
@@ -592,15 +624,25 @@ cmd_create_scene() {
     # Use centralized execute_unity_command function that handles Unity detection
     execute_unity_command "UnityVibe.Editor.CLI.CreateSceneFromCommandLine" "$scene_name" "$scene_path" "$scene_type" "$add_to_build"
     local exit_code=$?
-    
-    if [ $exit_code -eq 0 ]; then
+
+    if [ $exit_code -ne 0 ]; then
         echo ""
-        echo "✅ Scene created successfully: $scene_path/$scene_name.unity"
+        echo "Failed to submit create-scene command"
+        exit 1
+    fi
+
+    # A zero exit only means the command was submitted (file-watcher path) or the
+    # batch process returned; confirm the scene actually exists on disk before
+    # claiming success, rather than optimistically reporting it.
+    local scene_file="$scene_path/$scene_name.unity"
+    if wait_for_file "$scene_file" 20; then
+        echo ""
+        echo "Scene created successfully: $scene_file"
     else
         echo ""
-        echo "❌ Failed to create scene"
-        # Error details are now handled by execute_unity_command
-        exit 1
+        echo "WARNING: command submitted but scene file not found after 20s: $scene_file"
+        echo "Unity may not be processing commands. Check .vibe-unity/commands/logs/latest.log"
+        exit 2
     fi
 }
 
@@ -1201,13 +1243,17 @@ cmd_kill_unity() {
     echo "Killing Unity processes..."
     
     if command -v powershell.exe &> /dev/null; then
-        # Kill Unity Editor processes
-        powershell.exe "Get-Process | Where-Object {\$_.ProcessName -like '*Unity*'} | Stop-Process -Force" 2>/dev/null
-        echo "✅ Unity Editor processes terminated"
-        
-        # Kill Unity Hub processes
-        powershell.exe "Get-Process | Where-Object {\$_.ProcessName -like '*Unity Hub*'} | Stop-Process -Force" 2>/dev/null
-        echo "✅ Unity Hub processes terminated"
+        # Kill the Unity Editor only (exact name) plus its known child processes.
+        # Deliberately NOT a broad '*Unity*' match, which would also kill Unity Hub,
+        # the licensing client, and any unrelated process containing "Unity".
+        powershell.exe "Get-Process -Name 'Unity','UnityShaderCompiler','UnityPackageManager','UnityHelper' -ErrorAction SilentlyContinue | Stop-Process -Force" 2>/dev/null
+        echo "Unity Editor processes terminated"
+
+        # Kill Unity Hub processes only when explicitly forced.
+        if [[ "$force" == "true" ]]; then
+            powershell.exe "Get-Process -Name 'Unity Hub' -ErrorAction SilentlyContinue | Stop-Process -Force" 2>/dev/null
+            echo "Unity Hub processes terminated"
+        fi
         
         # Clean up lock files
         if [[ -f "Temp/UnityLockfile" ]]; then

--- a/Scripts/claude-compile-check.sh
+++ b/Scripts/claude-compile-check.sh
@@ -409,33 +409,66 @@ monitor_compilation() {
     fi
 }
 
-# Main execution function
-main() {
-    detect_project_name
-    resolve_unity_log
-    echo "Using Unity log: $UNITY_LOG_PATH" >&2
+# Deterministic, focus-free compile trigger: drop a recompile command for the
+# Unity file-watcher to process (it calls CompilationPipeline.RequestScriptCompilation).
+# Preferred over stealing the Unity window with AppActivate. Returns non-zero only
+# if the command queue directory is absent (caller can then fall back to focus).
+trigger_recompile_via_command() {
+    local cmd_dir=".vibe-unity/commands"
+    [[ -d "$cmd_dir" ]] || mkdir -p "$cmd_dir" 2>/dev/null || return 1
+    local f="$cmd_dir/recompile-$(date +%s%N).json"
+    printf '{"commands":[{"action":"recompile"}]}\n' > "$f" 2>/dev/null || return 1
+    echo "Requested recompile via command file: $(basename "$f")" >&2
+    return 0
+}
 
+# Run one trigger+monitor cycle (with internal retries). mode = command | focus.
+run_trigger_and_monitor() {
+    local mode="$1"
     local result=$RETRY_SENTINEL
-
     while [[ $result -eq $RETRY_SENTINEL ]] && [[ $RETRY_COUNT -le $MAX_RETRIES ]]; do
-        if ! focus_unity; then
-            output_result "ERROR" "0" "0" "Failed to focus Unity window. Ensure Unity is running."
-            return 2
+        if [[ "$mode" == "command" ]]; then
+            trigger_recompile_via_command || return 2
+            sleep 1
+        else
+            if ! focus_unity; then
+                output_result "ERROR" "0" "0" "Failed to focus Unity window. Ensure Unity is running."
+                return 2
+            fi
+            sleep 2
+            focus_wsl
+            sleep 1
         fi
-        sleep 2
-        focus_wsl
-        sleep 1
         monitor_compilation
         result=$?
         if [[ $result -eq $RETRY_SENTINEL ]] && [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; then
             sleep 2
         fi
     done
-
-    # If we exhausted retries still holding the sentinel, that's indeterminate.
     if [[ $result -eq $RETRY_SENTINEL ]]; then
         output_result "UNKNOWN" "0" "0" "Compilation could not be verified after retries. Treat as UNVERIFIED."
         return 2
+    fi
+    return $result
+}
+
+# Main execution function
+main() {
+    detect_project_name
+    resolve_unity_log
+    echo "Using Unity log: $UNITY_LOG_PATH" >&2
+
+    # Primary: focus-free command trigger.
+    run_trigger_and_monitor "command"
+    local result=$?
+
+    # Fallback: if the command trigger could not confirm a compile (e.g. the file
+    # watcher is disabled), try the legacy window-focus trigger once.
+    if [[ $result -eq 2 ]]; then
+        echo "Command trigger did not confirm compilation; trying window-focus fallback..." >&2
+        RETRY_COUNT=0
+        run_trigger_and_monitor "focus"
+        result=$?
     fi
 
     return $result

--- a/Scripts/claude-compile-check.sh
+++ b/Scripts/claude-compile-check.sh
@@ -1,24 +1,36 @@
 #!/bin/bash
 
 # claude-compile-check.sh - Unity compilation validator for claude-code integration
-# 
+#
 # Purpose: Validates Unity C# script compilation after claude-code makes changes
 # Returns structured output with error/warning details and precise file locations
 #
 # Exit Codes:
 #   0 = Success (no compilation errors)
 #   1 = Compilation errors found
-#   2 = Compilation timeout or Unity not accessible
-#   3 = Script execution error
+#   2 = Indeterminate: Unity not reachable, log not found, or no compilation
+#       evidence observed within the timeout. NOT treated as success.
+#   3 = Script execution error (bad usage)
 #
-# Usage: ./claude-compile-check.sh [--include-warnings]
+# Usage: ./claude-compile-check.sh [--include-warnings] [--log-path PATH]
+#
+# Environment:
+#   VIBE_UNITY_LOG  Override path to Unity's Editor.log (highest precedence).
 
-UNITY_LOG_PATH="/mnt/c/Users/matth/AppData/Local/Unity/Editor/Editor.log"
+set -uo pipefail
+
 INCLUDE_WARNINGS=false
-SCRIPT_VERSION="1.5.2"
+SCRIPT_VERSION="2.1.0"
 PROJECT_NAME=""
 RETRY_COUNT=0
 MAX_RETRIES=2
+LOG_PATH_OVERRIDE=""
+UNITY_LOG_PATH=""
+
+# Internal sentinel returned by monitor_compilation to request a retry.
+# Kept distinct from the documented exit codes (0/1/2/3) so a genuine script
+# error can never be mistaken for "retry needed".
+readonly RETRY_SENTINEL=10
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
@@ -27,18 +39,30 @@ while [[ $# -gt 0 ]]; do
             INCLUDE_WARNINGS=true
             shift
             ;;
+        --log-path)
+            LOG_PATH_OVERRIDE="${2:-}"
+            if [[ -z "$LOG_PATH_OVERRIDE" ]]; then
+                echo "ERROR: --log-path requires a value" >&2
+                exit 3
+            fi
+            shift 2
+            ;;
         --help|-h)
-            echo "Usage: $0 [--include-warnings]"
+            echo "Usage: $0 [--include-warnings] [--log-path PATH]"
             echo "Validates Unity compilation for claude-code integration"
             echo ""
             echo "Options:"
             echo "  --include-warnings  Include warning details in output"
+            echo "  --log-path PATH     Path to Unity Editor.log (overrides auto-detect)"
             echo "  --help, -h          Show this help message"
+            echo ""
+            echo "Environment:"
+            echo "  VIBE_UNITY_LOG      Path to Unity Editor.log (highest precedence)"
             echo ""
             echo "Exit codes:"
             echo "  0 = Success (no errors)"
             echo "  1 = Compilation errors found"
-            echo "  2 = Timeout/Unity not found"
+            echo "  2 = Indeterminate (Unity not reachable / no evidence observed)"
             echo "  3 = Script execution error"
             exit 0
             ;;
@@ -50,96 +74,134 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# Portable byte size of a file (replaces GNU-specific `stat -c%s`).
+file_size() {
+    wc -c < "$1" 2>/dev/null | tr -d ' '
+}
+
+# Resolve the Unity Editor.log path across WSL and git-bash, with overrides.
+# Precedence: VIBE_UNITY_LOG > --log-path > auto-detect > legacy fallback.
+resolve_unity_log() {
+    if [[ -n "${VIBE_UNITY_LOG:-}" ]]; then
+        UNITY_LOG_PATH="$VIBE_UNITY_LOG"
+        return
+    fi
+    if [[ -n "$LOG_PATH_OVERRIDE" ]]; then
+        UNITY_LOG_PATH="$LOG_PATH_OVERRIDE"
+        return
+    fi
+
+    local localappdata=""
+    local uname_s
+    uname_s="$(uname -s 2>/dev/null || echo unknown)"
+
+    if grep -qiE 'microsoft|wsl' /proc/version 2>/dev/null; then
+        # WSL: ask Windows for %LOCALAPPDATA%, translate to a /mnt path.
+        local win
+        win="$(cmd.exe /c "echo %LOCALAPPDATA%" 2>/dev/null | tr -d '\r')"
+        if [[ -n "$win" && "$win" != "%LOCALAPPDATA%" ]] && command -v wslpath >/dev/null 2>&1; then
+            localappdata="$(wslpath -u "$win" 2>/dev/null)"
+        fi
+    elif [[ "$uname_s" == MINGW* || "$uname_s" == MSYS* || "$uname_s" == CYGWIN* ]]; then
+        # git-bash / MSYS / Cygwin: %LOCALAPPDATA% is exported as a Windows path.
+        if [[ -n "${LOCALAPPDATA:-}" ]]; then
+            if command -v cygpath >/dev/null 2>&1; then
+                localappdata="$(cygpath -u "$LOCALAPPDATA" 2>/dev/null)"
+            else
+                # Best-effort: C:\Users\x -> /c/Users/x
+                localappdata="$(echo "$LOCALAPPDATA" | sed -e 's|\\|/|g' -e 's|^\([A-Za-z]\):|/\L\1|')"
+            fi
+        fi
+    fi
+
+    if [[ -n "$localappdata" ]]; then
+        UNITY_LOG_PATH="$localappdata/Unity/Editor/Editor.log"
+    else
+        # Last-resort legacy fallback; warn loudly since this is user-specific.
+        UNITY_LOG_PATH="/mnt/c/Users/$(whoami)/AppData/Local/Unity/Editor/Editor.log"
+        echo "WARNING: could not auto-detect Unity log path; falling back to $UNITY_LOG_PATH" >&2
+        echo "         Set VIBE_UNITY_LOG or pass --log-path if this is wrong." >&2
+    fi
+}
+
 # Function to output structured results
 output_result() {
     local status="$1"
     local error_count="$2"
     local warning_count="$3"
     local details="$4"
-    
+
     echo "STATUS: $status"
     echo "ERRORS: $error_count"
     echo "WARNINGS: $warning_count"
     if [[ -n "$details" ]]; then
         echo "DETAILS:"
-        echo "$details"
+        # Use %b so the accumulated literal "\n" separators render as newlines.
+        printf '%b\n' "$details"
     fi
     echo "SCRIPT_VERSION: $SCRIPT_VERSION"
 }
 
 # Function to detect project name from current directory
 detect_project_name() {
-    local current_dir=$(pwd)
-    PROJECT_NAME=$(basename "$current_dir")
+    PROJECT_NAME="$(basename "$(pwd)")"
     echo "Detected project name: $PROJECT_NAME" >&2
 }
 
 # Function to focus Unity window for recompilation
 focus_unity() {
     local project_pattern="$PROJECT_NAME"
-    
-    # If project name detection failed, try to find any Unity window
     if [[ -z "$project_pattern" ]]; then
         project_pattern="Unity"
     fi
-    
-    powershell.exe -Command "
+
+    # Note: stderr is intentionally preserved so "No Unity process found" and the
+    # window-mismatch warning reach the caller's log instead of being discarded.
+    powershell.exe -NoProfile -Command "
     \$unityProcesses = Get-Process -Name 'Unity' -ErrorAction SilentlyContinue | Where-Object { \$_.MainWindowTitle -ne '' };
     \$targetUnity = \$null;
-    
-    # First try to find Unity window with project name
     if ('$project_pattern' -ne 'Unity') {
         \$targetUnity = \$unityProcesses | Where-Object { \$_.MainWindowTitle -like '*$project_pattern*' } | Select-Object -First 1;
     }
-    
-    # If not found, get the first Unity window
     if (-not \$targetUnity -and \$unityProcesses) {
         \$targetUnity = \$unityProcesses | Select-Object -First 1;
-        Write-Host \"Warning: Could not find Unity window for project '$project_pattern', using first Unity window: \$((\$targetUnity).MainWindowTitle)\" -ForegroundColor Yellow;
+        Write-Host \"Warning: Could not find Unity window for project '$project_pattern', using first Unity window: \$((\$targetUnity).MainWindowTitle)\";
     }
-    
     if (\$targetUnity) {
         Add-Type -AssemblyName Microsoft.VisualBasic;
         [Microsoft.VisualBasic.Interaction]::AppActivate(\$targetUnity.Id);
         Write-Host \"Unity focused for compilation check: \$((\$targetUnity).MainWindowTitle)\";
+        exit 0
     } else {
-        Write-Host 'No Unity process found' -ForegroundColor Red;
+        Write-Host 'No Unity process found';
         exit 1
-    }" 2>/dev/null
-    
+    }"
     return $?
 }
 
-# Function to focus back to WSL terminal
+# Function to focus back to the calling terminal (best-effort; non-fatal).
 focus_wsl() {
-    powershell.exe -Command "
-    \$wsl = Get-Process -Name 'WindowsTerminal' -ErrorAction SilentlyContinue | Select-Object -First 1;
-    if (\$wsl) {
-        Add-Type -AssemblyName Microsoft.VisualBasic;
-        [Microsoft.VisualBasic.Interaction]::AppActivate(\$wsl.Id);
-    } else {
-        \$cmd = Get-Process -Name 'cmd' -ErrorAction SilentlyContinue | Select-Object -First 1;
-        if (\$cmd) {
+    powershell.exe -NoProfile -Command "
+    \$names = @('WindowsTerminal','cmd','Code','alacritty','ConEmu64','ConEmu');
+    foreach (\$n in \$names) {
+        \$p = Get-Process -Name \$n -ErrorAction SilentlyContinue | Select-Object -First 1;
+        if (\$p) {
             Add-Type -AssemblyName Microsoft.VisualBasic;
-            [Microsoft.VisualBasic.Interaction]::AppActivate(\$cmd.Id);
+            [Microsoft.VisualBasic.Interaction]::AppActivate(\$p.Id);
+            break
         }
-    }" 2>/dev/null
+    }" 2>/dev/null || true
 }
 
 # Function to check Unity compilation status via status file
 check_unity_compilation_status() {
     local status_file=".vibe-unity/status/compilation.json"
-    
-    # Check if status file exists
     if [[ ! -f "$status_file" ]]; then
         echo "NOT_FOUND"
         return
     fi
-    
-    # Try to read the file (will fail if locked)
     local file_content=""
     if file_content=$(cat "$status_file" 2>/dev/null); then
-        # File is unlocked, parse status
         if echo "$file_content" | grep -q '"status":"compiling"'; then
             echo "COMPILING"
         elif echo "$file_content" | grep -q '"status":"complete"'; then
@@ -148,7 +210,6 @@ check_unity_compilation_status() {
             echo "UNKNOWN"
         fi
     else
-        # File is locked (compilation in progress)
         echo "LOCKED"
     fi
 }
@@ -160,49 +221,35 @@ parse_compilation_results() {
     local warnings=""
     local error_count=0
     local warning_count=0
-    
-    # Parse compilation errors
+
     while IFS= read -r line; do
         if [[ "$line" =~ ^(.+)\(([0-9]+),([0-9]+)\):\ error\ (.+):\ (.+)$ ]]; then
-            # C# compilation error format: File(line,col): error CS####: Message
             local file="${BASH_REMATCH[1]}"
             local line_num="${BASH_REMATCH[2]}"
             local error_msg="${BASH_REMATCH[5]}"
-            
-            # Clean up file path for better readability
             file=$(echo "$file" | sed 's|.*[/\\]Packages[/\\]|./Packages/|' | sed 's|.*[/\\]Assets[/\\]|./Assets/|')
-            
             errors="${errors}  [$file:$line_num] $error_msg\n"
-            ((error_count++))
+            ((++error_count))
         elif [[ "$line" =~ error\ CS[0-9]+: ]]; then
-            # Generic error pattern
             local error_msg=$(echo "$line" | sed 's/.*error CS[0-9]*: //')
             errors="${errors}  [Unknown] $error_msg\n"
-            ((error_count++))
+            ((++error_count))
         fi
     done <<< "$log_content"
-    
-    # Always parse warnings to get accurate count
+
     while IFS= read -r line; do
-        # Pattern 1: Standard C# warning format with file location (Windows or Unix paths)
-        # Example: Assets\Scripts\Test.cs(10,5): warning CS0168: The variable 'test' is declared but never used
         if [[ "$line" =~ ^(.+)\(([0-9]+),([0-9]+)\):\ warning\ (CS[0-9]+):\ (.+)$ ]]; then
-            ((warning_count++))
+            ((++warning_count))
             if [[ "$INCLUDE_WARNINGS" == "true" ]]; then
                 local file="${BASH_REMATCH[1]}"
                 local line_num="${BASH_REMATCH[2]}"
-                local col_num="${BASH_REMATCH[3]}"
                 local warning_code="${BASH_REMATCH[4]}"
                 local warning_msg="${BASH_REMATCH[5]}"
-                
-                # Clean up file path (handle both Windows backslashes and Unix forward slashes)
                 file=$(echo "$file" | sed 's|\\|/|g' | sed 's|.*[/]Packages[/]|./Packages/|' | sed 's|.*[/]Assets[/]|./Assets/|')
-                
                 warnings="${warnings}  [$file:$line_num] WARNING $warning_code: $warning_msg\n"
             fi
-        # Pattern 2: Generic warning pattern
         elif [[ "$line" =~ warning\ (CS[0-9]+):\ (.+)$ ]]; then
-            ((warning_count++))
+            ((++warning_count))
             if [[ "$INCLUDE_WARNINGS" == "true" ]]; then
                 local warning_code="${BASH_REMATCH[1]}"
                 local warning_msg="${BASH_REMATCH[2]}"
@@ -210,24 +257,17 @@ parse_compilation_results() {
             fi
         fi
     done <<< "$log_content"
-    
-    # Combine results
+
     local details=""
-    if [[ -n "$errors" ]]; then
-        details="${details}${errors}"
-    fi
-    if [[ -n "$warnings" ]]; then
-        details="${details}${warnings}"
-    fi
-    
+    [[ -n "$errors" ]] && details="${details}${errors}"
+    [[ -n "$warnings" ]] && details="${details}${warnings}"
+
     echo "$error_count|$warning_count|$details"
 }
 
 # Function to check if compilation logs exist
 check_compilation_logs() {
     local log_content="$1"
-    
-    # Check for various compilation indicators
     if echo "$log_content" | grep -q "CompileScripts\|Reloading assemblies\|Compilation\|Nothing to compile"; then
         return 0
     fi
@@ -236,76 +276,63 @@ check_compilation_logs() {
 
 # Function to monitor Unity compilation with timeout
 monitor_compilation() {
-    local timeout=45  # Increased timeout for compilation checking
+    local timeout=45
     local elapsed=0
-    
-    # Verify Unity log exists
+
     if [[ ! -f "$UNITY_LOG_PATH" ]]; then
         output_result "ERROR" "0" "0" "Unity Editor log not found at: $UNITY_LOG_PATH"
         return 2
     fi
-    
-    # Get initial log size to track new entries
-    local initial_size=$(stat -c%s "$UNITY_LOG_PATH")
+
+    local initial_size
+    initial_size=$(file_size "$UNITY_LOG_PATH")
+    local current_size="$initial_size"
     local compilation_started=false
-    local nothing_to_compile=false
     local complete_checks=0
-    
+
     while [[ $elapsed -lt $timeout ]]; do
-        local current_size=$(stat -c%s "$UNITY_LOG_PATH")
-        
-        # Check Unity compilation status via status file
-        local unity_status=$(check_unity_compilation_status)
-        
-        # If Unity is compiling (locked file or compiling status), track compilation activity
-        if [[ "$unity_status" == "LOCKED" ]] || [[ "$unity_status" == "COMPILING" ]]; then
+        current_size=$(file_size "$UNITY_LOG_PATH")
+        local unity_status
+        unity_status=$(check_unity_compilation_status)
+
+        if [[ "$unity_status" == "LOCKED" || "$unity_status" == "COMPILING" ]]; then
             compilation_started=true
             echo "Unity compilation detected via status file - compilation in progress..." >&2
         elif [[ "$unity_status" == "COMPLETE" ]]; then
-            # If Unity is already complete and no compilation was started, 
-            # and no new log entries, then nothing to compile
-            if [[ "$compilation_started" == "false" ]] && [[ $current_size -eq $initial_size ]]; then
-                echo "Unity compilation is already complete, no new compilation detected" >&2
+            if [[ "$compilation_started" == "false" && $current_size -eq $initial_size ]]; then
+                echo "Unity status complete and no new log activity; nothing to compile" >&2
                 output_result "SUCCESS" "0" "0" "No compilation required - Unity is up to date"
                 return 0
             fi
-            # Count consecutive "complete" status checks to prevent infinite loops
             if [[ "$compilation_started" == "true" ]]; then
-                ((complete_checks++))
+                ((++complete_checks))
                 if [[ $complete_checks -ge 3 ]]; then
                     echo "Unity shows complete status - treating as success" >&2
                     output_result "SUCCESS" "0" "0" "Compilation completed successfully"
                     return 0
                 fi
             fi
-            echo "Unity compilation completed via status file" >&2
         fi
-        
+
         if [[ $current_size -gt $initial_size ]]; then
-            # Get new log entries since monitoring started
-            local new_entries=$(tail -c +$((initial_size + 1)) "$UNITY_LOG_PATH")
-            
-            # Check for "nothing to compile" scenario
+            local new_entries
+            new_entries=$(tail -c +$((initial_size + 1)) "$UNITY_LOG_PATH")
+
             if echo "$new_entries" | grep -q "Nothing to compile\|All compiler tasks finished\|Compilation succeeded"; then
-                nothing_to_compile=true
                 output_result "SUCCESS" "0" "0" "No compilation needed - all scripts up to date"
                 return 0
             fi
-            
-            # Check for compilation start indicators
+
             if [[ "$compilation_started" == "false" ]] && echo "$new_entries" | grep -q "Reloading assemblies\|CompileScripts\|Start importing"; then
                 compilation_started=true
             fi
-            
-            # Check for compilation completion indicators
+
             if echo "$new_entries" | grep -q "Reloading assemblies after forced synchronous recompile\|Finished compiling graph\|CompileScripts:.*ms\|Hotreload:.*ms\|PostProcessAllAssets:.*ms"; then
-                
-                # Parse the compilation results
-                local parse_result=$(parse_compilation_results "$new_entries")
-                local error_count=$(echo "$parse_result" | cut -d'|' -f1)
-                local warning_count=$(echo "$parse_result" | cut -d'|' -f2)
-                local details=$(echo "$parse_result" | cut -d'|' -f3-)
-                
+                local parse_result error_count warning_count details
+                parse_result=$(parse_compilation_results "$new_entries")
+                error_count=$(echo "$parse_result" | cut -d'|' -f1)
+                warning_count=$(echo "$parse_result" | cut -d'|' -f2)
+                details=$(echo "$parse_result" | cut -d'|' -f3-)
                 if [[ $error_count -eq 0 ]]; then
                     output_result "SUCCESS" "$error_count" "$warning_count" "$details"
                     return 0
@@ -314,58 +341,52 @@ monitor_compilation() {
                     return 1
                 fi
             fi
-            
-            # Check for compilation errors in real-time
+
             if echo "$new_entries" | grep -q "error CS[0-9]*:"; then
-                # Found errors, but wait a bit more to get complete error list
                 sleep 2
-                
-                # Get final log state
-                local final_entries=$(tail -c +$((initial_size + 1)) "$UNITY_LOG_PATH")
-                local parse_result=$(parse_compilation_results "$final_entries")
-                local error_count=$(echo "$parse_result" | cut -d'|' -f1)
-                local warning_count=$(echo "$parse_result" | cut -d'|' -f2)
-                local details=$(echo "$parse_result" | cut -d'|' -f3-)
-                
+                local final_entries parse_result error_count warning_count details
+                final_entries=$(tail -c +$((initial_size + 1)) "$UNITY_LOG_PATH")
+                parse_result=$(parse_compilation_results "$final_entries")
+                error_count=$(echo "$parse_result" | cut -d'|' -f1)
+                warning_count=$(echo "$parse_result" | cut -d'|' -f2)
+                details=$(echo "$parse_result" | cut -d'|' -f3-)
                 output_result "ERRORS" "$error_count" "$warning_count" "$details"
                 return 1
             fi
         fi
-        
+
         sleep 1
-        ((elapsed++))
-        
-        # If Unity is still compiling but we're approaching timeout, give more time
-        if [[ ("$unity_status" == "LOCKED" || "$unity_status" == "COMPILING") ]] && [[ $elapsed -gt $((timeout - 10)) ]]; then
+        ((++elapsed))
+
+        if [[ "$unity_status" == "LOCKED" || "$unity_status" == "COMPILING" ]] && [[ $elapsed -gt $((timeout - 10)) ]]; then
             echo "Unity still compiling near timeout, extending wait..." >&2
-            timeout=$((timeout + 15))  # Give 15 more seconds
+            timeout=$((timeout + 15))
         fi
     done
-    
-    # Timeout reached - check Unity one more time and logs
-    local final_unity_status=$(check_unity_compilation_status)
-    local final_entries=""
-    if [[ $current_size -gt $initial_size ]]; then
+
+    # Timeout reached - re-read state explicitly (do not rely on loop-local size).
+    local final_unity_status final_size final_entries=""
+    final_unity_status=$(check_unity_compilation_status)
+    final_size=$(file_size "$UNITY_LOG_PATH")
+    if [[ ${final_size:-0} -gt ${initial_size:-0} ]]; then
         final_entries=$(tail -c +$((initial_size + 1)) "$UNITY_LOG_PATH")
     fi
-    
-    # If Unity is still compiling, this might be a longer compilation
-    if [[ "$final_unity_status" == "LOCKED" ]] || [[ "$final_unity_status" == "COMPILING" ]]; then
+
+    if [[ "$final_unity_status" == "LOCKED" || "$final_unity_status" == "COMPILING" ]]; then
         echo "Unity still compiling at timeout (status: $final_unity_status)" >&2
         if [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; then
-            ((RETRY_COUNT++))
-            echo "Unity still compiling. Retrying (attempt $((RETRY_COUNT + 1))/$((MAX_RETRIES + 1)))..." >&2
-            return 3  # Signal retry needed
+            ((++RETRY_COUNT))
+            echo "Retrying (attempt $((RETRY_COUNT + 1))/$((MAX_RETRIES + 1)))..." >&2
+            return $RETRY_SENTINEL
         fi
     fi
-    
-    # If we have compilation logs, analyze them
+
     if check_compilation_logs "$final_entries"; then
-        local parse_result=$(parse_compilation_results "$final_entries")
-        local error_count=$(echo "$parse_result" | cut -d'|' -f1)
-        local warning_count=$(echo "$parse_result" | cut -d'|' -f2)
-        local details=$(echo "$parse_result" | cut -d'|' -f3-)
-        
+        local parse_result error_count warning_count details
+        parse_result=$(parse_compilation_results "$final_entries")
+        error_count=$(echo "$parse_result" | cut -d'|' -f1)
+        warning_count=$(echo "$parse_result" | cut -d'|' -f2)
+        details=$(echo "$parse_result" | cut -d'|' -f3-)
         if [[ $error_count -eq 0 ]]; then
             output_result "SUCCESS" "$error_count" "$warning_count" "Compilation completed (found in logs after timeout)"
             return 0
@@ -374,49 +395,49 @@ monitor_compilation() {
             return 1
         fi
     fi
-    
-    # No compilation logs found
+
     if [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; then
-        ((RETRY_COUNT++))
-        echo "No compilation logs found. Retrying (attempt $((RETRY_COUNT + 1))/$((MAX_RETRIES + 1)))..." >&2
-        return 3  # Signal retry needed
+        ((++RETRY_COUNT))
+        echo "No compilation evidence yet. Retrying (attempt $((RETRY_COUNT + 1))/$((MAX_RETRIES + 1)))..." >&2
+        return $RETRY_SENTINEL
     else
-        # Assume nothing to compile after retries
-        output_result "SUCCESS" "0" "0" "No compilation activity detected - assuming all scripts are up to date"
-        return 0
+        # IMPORTANT: never report SUCCESS when we observed no compilation evidence.
+        # The whole point of this tool is to *confirm* compilation; "couldn't tell"
+        # is reported as indeterminate (exit 2), not a clean pass.
+        output_result "UNKNOWN" "0" "0" "No compilation evidence observed. Unity may not be running, auto-refresh may be disabled, or the trigger failed. Treat as UNVERIFIED."
+        return 2
     fi
 }
 
 # Main execution function
 main() {
-    # Step 0: Detect project name
     detect_project_name
-    
-    local result=3  # Start with retry needed
-    
-    while [[ $result -eq 3 ]] && [[ $RETRY_COUNT -le $MAX_RETRIES ]]; do
-        # Step 1: Focus Unity to trigger compilation
+    resolve_unity_log
+    echo "Using Unity log: $UNITY_LOG_PATH" >&2
+
+    local result=$RETRY_SENTINEL
+
+    while [[ $result -eq $RETRY_SENTINEL ]] && [[ $RETRY_COUNT -le $MAX_RETRIES ]]; do
         if ! focus_unity; then
             output_result "ERROR" "0" "0" "Failed to focus Unity window. Ensure Unity is running."
             return 2
         fi
-        
-        # Brief pause to allow Unity to process the focus
         sleep 2
-        
-        # Step 2: Focus back to WSL terminal
         focus_wsl
         sleep 1
-        
-        # Step 3: Monitor compilation and return results
         monitor_compilation
         result=$?
-        
-        if [[ $result -eq 3 ]] && [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; then
-            sleep 2  # Wait before retry
+        if [[ $result -eq $RETRY_SENTINEL ]] && [[ $RETRY_COUNT -lt $MAX_RETRIES ]]; then
+            sleep 2
         fi
     done
-    
+
+    # If we exhausted retries still holding the sentinel, that's indeterminate.
+    if [[ $result -eq $RETRY_SENTINEL ]]; then
+        output_result "UNKNOWN" "0" "0" "Compilation could not be verified after retries. Treat as UNVERIFIED."
+        return 2
+    fi
+
     return $result
 }
 


### PR DESCRIPTION
Implements the code-review fixes (`Documentation~/CODE_REVIEW_AND_FEATURE_ROADMAP.md`). All C# compile-verified (0 errors) on Unity 6000.4.9f1 via the test rig; key features runtime-verified.

## Highlights
- **Focus-free compile trigger** — new `recompile`/`refresh` command calls `CompilationPipeline.RequestScriptCompilation()`; `claude-compile-check.sh` drops it as the primary trigger instead of stealing the Unity window (`AppActivate`). Focus kept only as a fallback. Verified end-to-end focus-free.
- **Result protocol** — per-command `results/*.result.json`; failed commands route to `failed/` instead of being archived as `processed/`.
- **Console capture** — `logMessageReceivedThreaded` buffered to `.vibe-unity/logs/console.json`.
- **Round-trip-safe scene export** — full `SceneState` + `JsonUtility` (was dropping all non-script components and producing an unreadable schema).

## Correctness / robustness
- Portable Unity log path; never report SUCCESS without compile evidence (exit 2 UNKNOWN); exit-code fix; `.gitattributes` LF for scripts.
- `PackageInfo.FindForAssembly` for path/version; honest setup; doc-updater no longer truncates CLAUDE.md (+ `.bak`).
- Component-parameter / settings-save failures surfaced, not swallowed.
- ScrollView wires real Scrollbars. Removed the Controller's broken racing `status/compilation.json` write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)